### PR TITLE
fix openapi schema generation of association and improve AsyncSession…

### DIFF
--- a/arcanus/association.py
+++ b/arcanus/association.py
@@ -119,15 +119,10 @@ class Association(Generic[A]):
             return instance
 
         return core_schema.with_default_schema(
-            core_schema.chain_schema(
-                [
-                    core_schema.with_info_wrap_validator_function(
-                        validate,
-                        cls.__get_pydantic_generic_schema__(generic_type, handler),
-                        field_name=handler.field_name,
-                    ),
-                    core_schema.is_instance_schema(cls),
-                ],
+            core_schema.with_info_wrap_validator_function(
+                validate,
+                cls.__get_pydantic_generic_schema__(generic_type, handler),
+                field_name=handler.field_name,
             ),
             default_factory=cls,
             serialization=cls.__get_pydantic_serialize_schema__(generic_type, handler),

--- a/arcanus/base.py
+++ b/arcanus/base.py
@@ -311,6 +311,7 @@ class TransmuterMetaclass(ModelMetaclass):
             if not info.frozen:
                 info = shallow_copy(info)
                 info.default = None
+                info.default_factory = None
                 field_definitions[field_name] = (Optional[info.annotation], info)
 
         self.__transmuter_update_model__ = create_model(

--- a/arcanus/materia/sqlalchemy/database.py
+++ b/arcanus/materia/sqlalchemy/database.py
@@ -832,7 +832,7 @@ class AsyncSession(SqlalchemyAsyncSession):
         expressions: Iterable[_ColumnExpressionArgument[bool]] | None = None,
         execution_options: OrmExecuteOptionsParameter = util.EMPTY_DICT,
         **filters,
-    ):
+    ) -> _T:
         return await util.greenlet_spawn(
             self.sync_session.one,
             entity,
@@ -849,8 +849,8 @@ class AsyncSession(SqlalchemyAsyncSession):
         expressions: Iterable[_ColumnExpressionArgument[bool]] | None = None,
         execution_options: OrmExecuteOptionsParameter = util.EMPTY_DICT,
         **filters,
-    ):
-        return await util.greenlet_spawn(
+    ) -> Optional[_T]:
+        r = await util.greenlet_spawn(
             self.sync_session.one_or_none,
             entity,
             options,
@@ -858,6 +858,7 @@ class AsyncSession(SqlalchemyAsyncSession):
             execution_options,
             **filters,
         )
+        return r
 
     async def first(
         self,
@@ -867,7 +868,7 @@ class AsyncSession(SqlalchemyAsyncSession):
         expressions: Iterable[_ColumnExpressionArgument[bool]] | None = None,
         execution_options: OrmExecuteOptionsParameter = util.EMPTY_DICT,
         **filters,
-    ):
+    ) -> Optional[_T]:
         return await util.greenlet_spawn(
             self.sync_session.first,
             entity,
@@ -900,7 +901,7 @@ class AsyncSession(SqlalchemyAsyncSession):
         expressions: Iterable[_ColumnExpressionArgument[bool]] | None = None,
         execution_options: OrmExecuteOptionsParameter = util.EMPTY_DICT,
         **filters,
-    ):
+    ) -> int:
         return await util.greenlet_spawn(
             self.sync_session.count,
             entity,
@@ -919,7 +920,7 @@ class AsyncSession(SqlalchemyAsyncSession):
         expressions: Iterable[_ColumnExpressionArgument[bool]] | None = None,
         execution_options: OrmExecuteOptionsParameter = util.EMPTY_DICT,
         **filters,
-    ):
+    ) -> Sequence[_T]:
         return await util.greenlet_spawn(
             self.sync_session.list,
             entity,


### PR DESCRIPTION
- fix openapi schema generation of Associations
- enforce both default & dafault factory tobe None in dynamic created Update Model
- improve typehint for sqlalchemy materia's AsyncSession helper methods