### PR TITLE
Implement `RelationGroupMap[K, T]` association with `attribute_keyed_list_dict` backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,12 +553,13 @@ Arcanus provides several association types to model different relationship patte
 
 Default factories are provided for convenience:
 
-| Field Helper          | Creates                                                  |
-| --------------------- | -------------------------------------------------------- |
-| `Relationship()`      | `Field(default_factory=Relation, frozen=True)`           |
-| `Relationships()`     | `Field(default_factory=RelationCollection, frozen=True)` |
-| `RelationMaps()`      | `Field(default_factory=RelationMap, frozen=True)`        |
-| `TypedRelationMaps()` | `Field(default_factory=TypedRelationMap, frozen=True)`   |
+| Field Helper            | Creates                                                  |
+| ----------------------- | -------------------------------------------------------- |
+| `Relationship()`        | `Field(default_factory=Relation, frozen=True)`           |
+| `Relationships()`       | `Field(default_factory=RelationCollection, frozen=True)` |
+| `MappedRelationship()`  | `Field(default_factory=RelationMap, frozen=True)`        |
+| `GroupedRelationship()` | `Field(default_factory=RelationGroupMap, frozen=True)`   |
+| `TypedRelationship()`   | `Field(default_factory=TypedRelationMap, frozen=True)`   |
 
 ### Relation
 
@@ -706,7 +707,7 @@ article = Article(
 `RelationMap[K, T]` is a `dict`-based association with **homogeneous** value types — all values share the same transmuter type. Use it for keyed one-to-many relationships.
 
 ```python
-from arcanus.association import RelationMap, RelationMaps
+from arcanus.association import RelationMap, MappedRelationship
 
 class ShelfItem(BaseTransmuter):
     id: Annotated[Optional[int], Identity] = Field(default=None, frozen=True)
@@ -716,7 +717,7 @@ class ShelfItem(BaseTransmuter):
 class Shelf(BaseTransmuter):
     id: Annotated[Optional[int], Identity] = Field(default=None, frozen=True)
     name: str
-    items: RelationMap[str, ShelfItem] = RelationMaps()
+    items: RelationMap[str, ShelfItem] = MappedRelationship()
 
 shelf = Shelf(id=1, name="Reference")
 
@@ -743,7 +744,7 @@ from typing import Literal
 class StrictCatalog(BaseTransmuter):
     id: Annotated[Optional[int], Identity] = Field(default=None)
     title: str
-    tags: RelationMap[Literal["python", "rust", "go"], Tag] = RelationMaps()
+    tags: RelationMap[Literal["python", "rust", "go"], Tag] = MappedRelationship()
 
 catalog = StrictCatalog(id=1, title="Languages")
 catalog.tags["python"] = Tag(id=1, name="Python")
@@ -761,7 +762,7 @@ from typing import Annotated, Optional
 from typing_extensions import TypedDict
 from pydantic import Field
 from arcanus.base import BaseTransmuter, Identity
-from arcanus.association import TypedRelationMap, TypedRelationMaps
+from arcanus.association import TypedRelationMap, TypedRelationship
 
 # Define polymorphic transmuter types
 class MediaItem(BaseTransmuter):
@@ -785,7 +786,7 @@ class DocumentMedia(TypedDict):
 class Gallery(BaseTransmuter):
     id: Annotated[Optional[int], Identity] = Field(default=None, frozen=True)
     name: str
-    media: TypedRelationMap[DocumentMedia] = TypedRelationMaps()
+    media: TypedRelationMap[DocumentMedia] = TypedRelationship()
 ```
 
 #### Basic Usage
@@ -871,7 +872,7 @@ class OptionalMedia(TypedDict, total=False):
 class FlexibleGallery(BaseTransmuter):
     id: Annotated[Optional[int], Identity] = Field(default=None, frozen=True)
     name: str
-    media: TypedRelationMap[OptionalMedia] = TypedRelationMaps()
+    media: TypedRelationMap[OptionalMedia] = TypedRelationship()
 
 # Only some keys need to be present
 gallery = FlexibleGallery(id=1, name="Partial")

--- a/arcanus/__init__.py
+++ b/arcanus/__init__.py
@@ -1,6 +1,10 @@
 from arcanus.association import (
+    GroupedRelationship,
+    MappedRelationship,
     Relation,
     RelationCollection,
+    RelationGroupMap,
+    RelationGroupMaps,
     RelationMap,
     RelationMaps,
     RelationSet,
@@ -8,6 +12,7 @@ from arcanus.association import (
     Relationships,
     TypedRelationMap,
     TypedRelationMaps,
+    TypedRelationship,
 )
 from arcanus.base import (
     BaseTransmuter,
@@ -19,11 +24,16 @@ __all__ = [
     "Transmuter",
     "Relation",
     "RelationCollection",
+    "RelationGroupMap",
+    "GroupedRelationship",
+    "RelationGroupMaps",
     "RelationMap",
+    "MappedRelationship",
     "RelationMaps",
     "RelationSet",
     "Relationship",
     "Relationships",
     "TypedRelationMap",
+    "TypedRelationship",
     "TypedRelationMaps",
 ]

--- a/arcanus/association.py
+++ b/arcanus/association.py
@@ -1932,7 +1932,7 @@ class RelationGroupMap(dict[K, list[T]], Association[T]):
                 self.__provided__.set(item.__transmuter_provided__)
 
     @ensure_loaded
-    def remove_item(self, key: K, value: T) -> None:
+    def discard(self, key: K, value: T) -> None:
         """Remove a single item from the group at *key*.
 
         Removes the key entirely if its list becomes empty.
@@ -1946,7 +1946,7 @@ class RelationGroupMap(dict[K, list[T]], Association[T]):
             super().__delitem__(key)
 
     @ensure_loaded
-    def flat_values(self) -> list[T]:
+    def flatten(self) -> list[T]:
         """Return all values across all keys as a flat list."""
         result: list[T] = []
         for lst in super().values():

--- a/arcanus/association.py
+++ b/arcanus/association.py
@@ -29,7 +29,7 @@ from typing import (
 
 from pydantic import Field, GetCoreSchemaHandler, TypeAdapter
 from pydantic_core import core_schema
-from typing_extensions import is_typeddict
+from typing_extensions import deprecated, is_typeddict
 
 from arcanus.materia.base import active_materia
 from arcanus.utils import get_cached_adapter
@@ -1449,6 +1449,512 @@ class RelationMap(dict[K, T], Association[T]):
 
 
 # built-in types must be put at front to avoid pydantic convert it to built-in types
+class RelationGroupMap(dict[K, list[T]], Association[T]):
+    """A dict-based association that groups multiple values under each key.
+
+    Unlike :class:`RelationMap` which maps ``dict[K, T]`` (one value per key,
+    silently dropping duplicates), this class stores ``dict[K, list[T]]`` so
+    that multiple items sharing the same key coexist.
+
+    Backed by :class:`~arcanus.materia.sqlalchemy.collections.KeyFuncListDict`
+    on the SQLAlchemy side (via ``attribute_keyed_list_dict``).
+
+    Usage::
+
+        class Article(BaseTransmuter):
+            generated_files: RelationGroupMap[str, File] = GroupedRelationship()
+    """
+
+    # new items are held in __payloads__, loaded items are kept in the dict itself
+    # __args__[0] = key type (K), __args__[1] = value type (T)
+    __payloads__: dict[K, list[T]]
+
+    @classmethod
+    def __get_pydantic_generic_schema__(
+        cls,
+        key_type: Type[K],
+        value_type: Type[T],
+        handler: GetCoreSchemaHandler,
+    ) -> core_schema.CoreSchema:
+        return core_schema.dict_schema(
+            keys_schema=handler.generate_schema(key_type),
+            values_schema=core_schema.list_schema(handler.generate_schema(value_type)),
+        )
+
+    @classmethod
+    def __get_pydantic_serialize_schema__(
+        cls,
+        key_type: Type[K],
+        value_type: Type[T],
+        handler: GetCoreSchemaHandler,
+    ) -> core_schema.SerSchema | None:
+        def serialize(association: RelationGroupMap[K, T], serializer) -> Any:
+            fields_set = getattr(
+                association.__instance__, "__pydantic_fields_set__", None
+            )
+            if fields_set is not None and association.field_name in fields_set:
+                return serializer(association.copy())
+            return serializer(dict.copy(association) | association.__payloads__)
+
+        return core_schema.wrap_serializer_function_ser_schema(
+            serialize,
+            schema=core_schema.dict_schema(
+                keys_schema=handler.generate_schema(key_type),
+                values_schema=core_schema.list_schema(
+                    handler.generate_schema(value_type)
+                ),
+            ),
+            when_used="always",
+        )
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: Type[RelationGroupMap[K, T]], handler: GetCoreSchemaHandler
+    ) -> core_schema.CoreSchema:
+        args = get_args(source_type)
+
+        if not args or len(args) < 2:
+            raise TypeError(
+                f"Two generic types (key, value) must be provided to {source_type}."
+            )
+
+        key_type = args[0]
+        value_type = args[1]
+
+        def validate(
+            value: Any,
+            handler: core_schema.ValidatorFunctionWrapHandler,
+            info: core_schema.ValidationInfo,
+        ) -> RelationGroupMap[K, T]:
+            if value is DefferedAssociation:
+                instance = cls()
+            elif type(value) is cls:
+                instance = value
+                instance.__payloads__ = handler(instance.__payloads__)
+            else:
+                instance = cls(handler(value))
+
+            instance.__args__ = (key_type, value_type)
+            instance.field_name = info.field_name  # pyright: ignore[reportAttributeAccessIssue]
+
+            return instance
+
+        return core_schema.with_default_schema(
+            core_schema.with_info_wrap_validator_function(
+                validate,
+                cls.__get_pydantic_generic_schema__(key_type, value_type, handler),
+            ),
+            default_factory=cls,
+            serialization=cls.__get_pydantic_serialize_schema__(
+                key_type, value_type, handler
+            ),
+        )
+
+    def __init__(self, payloads: Mapping[K, list[T]] | None = None):
+        super().__init__()
+        self.__instance__ = None
+        self.__loaded__ = False
+        self.__payloads__: dict[K, list[T]] = (
+            {k: list(v) for k, v in payloads.items()} if payloads else {}
+        )
+
+    @property
+    def __provided__(self) -> Any | None:
+        # The return type should be a dict-of-lists object provided by the current materia provider.
+        # For example, with SQLAlchemyMateria and collection_class=attribute_keyed_list_dict,
+        # it would be a KeyFuncListDict.
+        if not self.__instance_provider__:
+            return None
+        return getattr(self.__instance_provider__, self.used_name)
+
+    @cached_property
+    def __validator__(self) -> TypeAdapter[T]:
+        return get_cached_adapter(self.__args__[1])
+
+    @cached_property
+    def __list_validator__(self) -> TypeAdapter[list[T]]:
+        return get_cached_adapter(list[self.__args__[1]])
+
+    @cached_property
+    def __dict_validator__(self) -> TypeAdapter[dict[K, list[T]]]:
+        return get_cached_adapter(dict[self.__args__[0], list[self.__args__[1]]])
+
+    @cached_property
+    def __key_validator__(self) -> TypeAdapter[K]:
+        return get_cached_adapter(self.__args__[0])
+
+    def bless_key(self, key: Any) -> K:
+        """Validate and coerce a key into the key type."""
+        return self.__key_validator__.validate_python(key)
+
+    def bless_value(self, value: Any) -> T:
+        """Validate and coerce a single value into the value type."""
+        return self.__validator__.validate_python(value)
+
+    def bless_values(self, values: Iterable[Any]) -> list[T]:
+        """Validate and coerce a list of values into list[T]."""
+        return self.__list_validator__.validate_python(values)
+
+    def bless(self, value: Mapping[K, Any]) -> dict[K, list[T]]:
+        """Validate and coerce an entire mapping into dict[K, list[T]]."""
+        return self.__dict_validator__.validate_python(value)
+
+    def prepare(self, instance: Transmuter, field_name: str):
+        if self.__instance__ is not None:
+            return
+
+        self.field_name = field_name
+        self.field_info = type(instance).__pydantic_fields__[field_name]
+
+        self.__instance__ = instance
+
+        annotation = self.field_info.annotation
+        if isinstance(annotation, ForwardRef):
+            resolved_hints = get_type_hints(type(instance))
+            actual_type = resolved_hints[field_name]
+            args = get_args(actual_type)
+        else:
+            args = get_args(annotation)
+
+        self.__args__ = (args[0], args[1])
+
+        if self.__payloads__:
+            self._load()
+            self._merge_payloads()
+            self.__payloads__.clear()
+
+    def _merge_payloads(self) -> None:
+        """Merge __payloads__ into self (the loaded dict)."""
+        for key, values in self.__payloads__.items():
+            if key in self:
+                existing = super().__getitem__(key)
+                existing.extend(values)
+            else:
+                super().__setitem__(key, list(values))
+
+    @staticmethod
+    def ensure_loaded(
+        func: Callable[Concatenate[RelationGroupMap[K, T], P], R],
+    ) -> Callable[Concatenate[RelationGroupMap[K, T], P], R]:
+        @wraps(func)
+        def wrapper(
+            self: RelationGroupMap[K, T], *args: P.args, **kwargs: P.kwargs
+        ) -> R:
+            self._load()
+            return func(self, *args, **kwargs)
+
+        return wrapper
+
+    def _load(self):
+        # maybe during deepcopy from field default
+        if not self.__instance__:
+            return self
+
+        # or the relationship is already loaded
+        if self.__loaded__:
+            return self
+
+        active_materia.get().load_association(self)
+
+        # A: No provided, None
+        # B: provided value is empty, {}
+        if not self.__provided__:
+            return self
+
+        # Remove payloads whose key is already in __provided__
+        self.__payloads__ = {
+            k: v for k, v in self.__payloads__.items() if k not in self.__provided__
+        }
+
+        if len(self.__provided__) != super().__len__() or not super().__len__():
+            # Bless: __provided__ is a KeyFuncListDict (dict[K, list[ORM]])
+            super().clear()
+            for key, orm_list in self.__provided__.items():
+                super().__setitem__(key, self.bless_values(orm_list))
+        self.__loaded__ = True
+
+        return self
+
+    async def _aload(self):
+        # maybe during deepcopy from field default
+        if not self.__instance__:
+            return self
+
+        # or the relationship is already loaded
+        if self.__loaded__:
+            return self
+
+        # A: No provided, None
+        # B: provided value is empty, {}
+        if not (provided := await active_materia.get().aload_association(self)):
+            return self
+
+        # Remove payloads whose key is already in provided
+        self.__payloads__ = {
+            k: v for k, v in self.__payloads__.items() if k not in provided
+        }
+
+        if len(provided) != super().__len__() or not super().__len__():
+            super().clear()
+            for key, orm_list in provided.items():
+                super().__setitem__(key, self.bless_values(orm_list))
+        self.__loaded__ = True
+
+        return self
+
+    def __await__(self):
+        return self._aload().__await__()
+
+    @ensure_loaded
+    def __getitem__(self, key: K) -> list[T]:
+        key = self.bless_key(key)
+        return super().__getitem__(key)
+
+    @ensure_loaded
+    def __iter__(self):
+        return super().__iter__()
+
+    @ensure_loaded
+    def __len__(self):
+        return super().__len__()
+
+    @ensure_loaded
+    def __contains__(self, key: object) -> bool:
+        key = self.bless_key(key)
+        return super().__contains__(key)
+
+    @ensure_loaded
+    def __bool__(self):
+        return super().__len__() > 0
+
+    @ensure_loaded
+    def __setitem__(self, key: K, value: list[T]) -> None:
+        key = self.bless_key(key)
+        value = self.bless_values(value)
+        if self.__provided__ is not None:
+            # Remove old items from provider, then add new ones
+            if key in self.__provided__:
+                old_items = list(dict.__getitem__(self.__provided__, key))
+                for item in old_items:
+                    self.__provided__.remove(item)
+            for item in value:
+                self.__provided__.set(item.__transmuter_provided__)
+        super().__setitem__(key, value)
+
+    @ensure_loaded
+    def __delitem__(self, key: K) -> None:
+        key = self.bless_key(key)
+        if self.__provided__ is not None and key in self.__provided__:
+            old_items = list(dict.__getitem__(self.__provided__, key))
+            for item in old_items:
+                self.__provided__.remove(item)
+        super().__delitem__(key)
+
+    def __repr__(self):
+        args = getattr(self, "__args__", None)
+        if args and len(args) >= 2:
+            key_type = args[0]
+            value_type = args[1]
+            key_name = getattr(key_type, "__name__", repr(key_type))
+            value_name = getattr(value_type, "__name__", repr(value_type))
+        else:
+            key_name = value_name = "?"
+        return f"RelationGroupMap[{key_name}, {value_name}], instance={id(self.__instance__)}, size={super().__len__()}"
+
+    @ensure_loaded
+    def __str__(self):
+        return super().__str__()
+
+    @ensure_loaded
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, dict):
+            return dict.__eq__(self, other)
+        return False
+
+    @ensure_loaded
+    def __ne__(self, other: object) -> bool:
+        if isinstance(other, dict):
+            return dict.__ne__(self, other)
+        return True
+
+    @ensure_loaded
+    def __or__(self, other: Mapping[K, list[T]]) -> dict[K, list[T]]:
+        return dict.__or__(self.copy(), dict(other))
+
+    @ensure_loaded
+    def __ior__(self, other: Mapping[K, list[T]]) -> Self:
+        self.update(other)
+        return self
+
+    @ensure_loaded
+    def __reversed__(self):
+        return super().__reversed__()
+
+    @ensure_loaded
+    def get(self, key: K, default: list[T] | None = None) -> list[T] | None:
+        return super().get(self.bless_key(key), default)
+
+    @ensure_loaded
+    def keys(self):
+        return super().keys()
+
+    @ensure_loaded
+    def values(self):
+        return super().values()
+
+    @ensure_loaded
+    def items(self):
+        return super().items()
+
+    @overload
+    def pop(self, key: K) -> list[T]: ...
+
+    @overload
+    def pop(self, key: K, default: list[T]) -> list[T]: ...
+
+    @overload
+    def pop(self, key: K, default: D) -> list[T] | D: ...
+
+    @ensure_loaded
+    def pop(self, key: K, *args: Any) -> Any:
+        """Remove specified key and return the corresponding list."""
+        key = self.bless_key(key)
+        item = super().pop(key, *args)
+        if self.__provided__ is not None and key in self.__provided__:
+            old_items = list(dict.__getitem__(self.__provided__, key))
+            for old in old_items:
+                self.__provided__.remove(old)
+        return item
+
+    @ensure_loaded
+    def popitem(self) -> tuple[K, list[T]]:
+        """Remove and return an arbitrary (key, list) pair."""
+        key, items = super().popitem()
+        if self.__provided__ is not None and key in self.__provided__:
+            old_items = list(dict.__getitem__(self.__provided__, key))
+            for old in old_items:
+                self.__provided__.remove(old)
+        return key, items
+
+    @overload
+    def update(self, m: Mapping[K, list[T]], /, **kwargs: list[T]) -> None: ...
+    @overload
+    def update(self, m: Iterable[tuple[K, list[T]]], /, **kwargs: list[T]) -> None: ...
+    @overload
+    def update(self, **kwargs: list[T]) -> None: ...
+
+    @ensure_loaded
+    def update(
+        self,
+        *args: Mapping[K, list[T]] | Iterable[tuple[K, list[T]]],
+        **kwargs: list[T],
+    ) -> None:
+        """Update the dict with key-list pairs."""
+        merged: dict[K, list[T]] = {}
+        if args:
+            if isinstance(args[0], Mapping):
+                merged.update(args[0])
+            else:
+                merged.update(dict(*args))
+        if kwargs:
+            merged.update(kwargs)  # type: ignore[arg-type]
+
+        if not merged:
+            return
+
+        blessed = self.bless(merged)
+        if self.__provided__ is not None:
+            for key, items in blessed.items():
+                # Remove old items at this key from provider
+                if key in self.__provided__:
+                    old_items = list(dict.__getitem__(self.__provided__, key))
+                    for old in old_items:
+                        self.__provided__.remove(old)
+                # Add new items
+                for item in items:
+                    self.__provided__.set(item.__transmuter_provided__)
+        super().update(blessed)
+
+    @overload
+    def setdefault(self, key: K) -> list[T]: ...
+    @overload
+    def setdefault(self, key: K, default: list[T]) -> list[T]: ...
+
+    @ensure_loaded
+    def setdefault(self, key: K, default: list[T] | None = None) -> list[T]:
+        """If key is not in the dict, insert key with the default list."""
+        key = self.bless_key(key)
+        if key not in self:
+            if default is not None:
+                self[key] = default
+            else:
+                self[key] = []
+        return super().__getitem__(key)
+
+    @ensure_loaded
+    def clear(self) -> None:
+        """Remove all items."""
+        if self.__provided__ is not None:
+            # Remove each item individually so SQLAlchemy fires proper remove events
+            for key in list(dict.keys(self.__provided__)):
+                items = list(dict.__getitem__(self.__provided__, key))
+                for item in items:
+                    self.__provided__.remove(item)
+        super().clear()
+
+    @ensure_loaded
+    def copy(self) -> dict[K, list[T]]:
+        return {k: list(v) for k, v in super().items()}
+
+    # ── Convenience methods unique to grouped maps ──
+
+    @ensure_loaded
+    def append(self, key: K, value: T) -> None:
+        """Append a single item to the group at *key*, creating the group if needed."""
+        key = self.bless_key(key)
+        value = self.bless_value(value)
+        if key not in self:
+            super().__setitem__(key, [])
+        super().__getitem__(key).append(value)
+        if self.__provided__ is not None:
+            self.__provided__.set(value.__transmuter_provided__)
+
+    @ensure_loaded
+    def extend(self, key: K, values: Iterable[T]) -> None:
+        """Append multiple items to the group at *key*."""
+        key = self.bless_key(key)
+        values = self.bless_values(values)
+        if key not in self:
+            super().__setitem__(key, [])
+        super().__getitem__(key).extend(values)
+        if self.__provided__ is not None:
+            for item in values:
+                self.__provided__.set(item.__transmuter_provided__)
+
+    @ensure_loaded
+    def remove_item(self, key: K, value: T) -> None:
+        """Remove a single item from the group at *key*.
+
+        Removes the key entirely if its list becomes empty.
+        """
+        key = self.bless_key(key)
+        lst = super().__getitem__(key)
+        lst.remove(value)
+        if self.__provided__ is not None:
+            self.__provided__.remove(value.__transmuter_provided__)
+        if not lst:
+            super().__delitem__(key)
+
+    @ensure_loaded
+    def flat_values(self) -> list[T]:
+        """Return all values across all keys as a flat list."""
+        result: list[T] = []
+        for lst in super().values():
+            result.extend(lst)
+        return result
+
+
+# built-in types must be put at front to avoid pydantic convert it to built-in types
 class TypedRelationMap(dict, Association[TD]):
     """A dict-based association whose keys and per-key value types are defined
     by a ``TypedDict``.
@@ -1465,7 +1971,7 @@ class TypedRelationMap(dict, Association[TD]):
             video: Video
 
         class Document(BaseTransmuter):
-            files: TypedRelationMap[DocumentFiles] = TypedRelationMaps()
+            files: TypedRelationMap[DocumentFiles] = TypedRelationship()
 
     All values in the TypedDict **must** be ``Transmuter`` subclasses.
     """
@@ -1854,8 +2360,25 @@ if TYPE_CHECKING:
     )
 
 Relationship = partial(Field, default_factory=Relation, frozen=True)
-RelationMaps = partial(Field, default_factory=RelationMap, frozen=True)
-TypedRelationMaps = partial(Field, default_factory=TypedRelationMap, frozen=True)
+MappedRelationship = partial(Field, default_factory=RelationMap, frozen=True)
+GroupedRelationship = partial(Field, default_factory=RelationGroupMap, frozen=True)
+TypedRelationship = partial(Field, default_factory=TypedRelationMap, frozen=True)
+
+
+# Backward-compatible aliases (deprecated)
+@deprecated("Use MappedRelationship instead.")
+def RelationMaps(**kwargs: Any) -> Any:
+    return MappedRelationship(**kwargs)
+
+
+@deprecated("Use GroupedRelationship instead.")
+def RelationGroupMaps(**kwargs: Any) -> Any:
+    return GroupedRelationship(**kwargs)
+
+
+@deprecated("Use TypedRelationship instead.")
+def TypedRelationMaps(**kwargs: Any) -> Any:
+    return TypedRelationship(**kwargs)
 
 
 @overload

--- a/arcanus/materia/sqlalchemy/__init__.py
+++ b/arcanus/materia/sqlalchemy/__init__.py
@@ -1,8 +1,10 @@
 from arcanus.materia.sqlalchemy.base import SqlalchemyMateria
+from arcanus.materia.sqlalchemy.collections import attribute_keyed_list_dict
 from arcanus.materia.sqlalchemy.database import AsyncSession, Session
 
 __all__ = [
     "SqlalchemyMateria",
     "Session",
     "AsyncSession",
+    "attribute_keyed_list_dict",
 ]

--- a/arcanus/materia/sqlalchemy/collections.py
+++ b/arcanus/materia/sqlalchemy/collections.py
@@ -1,0 +1,87 @@
+"""Custom SQLAlchemy collection classes for arcanus associations."""
+
+from __future__ import annotations
+
+from operator import attrgetter
+from typing import Any, Callable
+
+from sqlalchemy.orm.collections import collection
+
+
+class KeyFuncListDict(dict):
+    """A dict-of-lists collection class for SQLAlchemy relationships.
+
+    Groups ORM objects by a key function into ``dict[str, list[ORM]]``.
+    Unlike ``attribute_keyed_dict`` which maps each key to a single value
+    (silently overwriting duplicates), this collection keeps all values
+    under the same key in a list.
+
+    Usage with SQLAlchemy::
+
+        relationship(
+            "Child",
+            collection_class=attribute_keyed_list_dict("role"),
+            ...
+        )
+    """
+
+    def __init__(self, keyfunc: Callable[[Any], Any]):
+        super().__init__()
+        self.keyfunc = keyfunc
+
+    @collection.appender  # type: ignore[misc]
+    def set(self, value: Any, _sa_initiator: Any = None) -> None:
+        """Append *value* to the list at ``keyfunc(value)``."""
+        key = self.keyfunc(value)
+        if key not in self:
+            dict.__setitem__(self, key, [])
+        dict.__getitem__(self, key).append(value)
+
+    @collection.remover  # type: ignore[misc]
+    def remove(self, value: Any, _sa_initiator: Any = None) -> None:
+        """Remove *value* from the list at ``keyfunc(value)``."""
+        key = self.keyfunc(value)
+        lst = dict.__getitem__(self, key)
+        lst.remove(value)
+        if not lst:
+            dict.__delitem__(self, key)
+
+    @collection.iterator  # type: ignore[misc]
+    def _values(self):
+        """Yield every individual ORM object across all keys."""
+        for lst in dict.values(self):
+            yield from lst
+
+    def __repr__(self) -> str:
+        return f"KeyFuncListDict({dict.__repr__(self)})"
+
+
+def attribute_keyed_list_dict(attr_name: str) -> type[KeyFuncListDict]:
+    """Collection class factory grouping ORM objects by attribute into lists.
+
+    Drop-in replacement for ``attribute_keyed_dict`` when multiple rows
+    may share the same key value.
+
+    Usage::
+
+        relationship(
+            "ArticleGeneratedFile",
+            collection_class=attribute_keyed_list_dict("role"),
+            ...
+        )
+
+    Args:
+        attr_name: The attribute name on the child ORM model used as grouping key.
+
+    Returns:
+        A callable that constructs a :class:`KeyFuncListDict`.
+    """
+    getter = attrgetter(attr_name)
+
+    class _Factory(KeyFuncListDict):
+        def __init__(self) -> None:
+            super().__init__(keyfunc=getter)
+
+    _Factory.__name__ = f"KeyFuncListDict(keyfunc={attr_name!r})"
+    _Factory.__qualname__ = _Factory.__name__
+    return _Factory

--- a/tests/models.py
+++ b/tests/models.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import (
 from sqlalchemy.orm.collections import attribute_keyed_dict
 
 from arcanus.base import TransmuterProxiedMixin
+from arcanus.materia.sqlalchemy.collections import attribute_keyed_list_dict
 
 
 class Base(DeclarativeBase, TransmuterProxiedMixin):
@@ -592,6 +593,8 @@ __all__ = [
     "BlogPost",
     "BlogTag",
     "BlogPostTag",
+    "Warehouse",
+    "WarehouseItem",
 ]
 
 
@@ -674,3 +677,44 @@ class BlogPost(Base):
     # ── Association proxies ──
     author_name: AssociationProxy[str] = association_proxy("author", "name")
     tag_labels: AssociationProxy[list[str]] = association_proxy("tags", "label")
+
+
+# ── RelationGroupMap test models ──
+
+
+class Warehouse(Base):
+    """Warehouse with items grouped by category via attribute_keyed_list_dict."""
+
+    __tablename__ = "warehouse"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+
+    # Dict-of-lists relationship keyed by WarehouseItem.category
+    items: Mapped[dict[str, list["WarehouseItem"]]] = relationship(
+        "WarehouseItem",
+        collection_class=attribute_keyed_list_dict("category"),
+        back_populates="warehouse",
+        cascade="all, delete-orphan",
+    )
+
+
+class WarehouseItem(Base):
+    """Item in a warehouse, grouped by category."""
+
+    __tablename__ = "warehouse_item"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    category: Mapped[str] = mapped_column(String(100), nullable=False)
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    quantity: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    warehouse_id: Mapped[int] = mapped_column(
+        ForeignKey("warehouse.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    warehouse: Mapped[Warehouse] = relationship(
+        "Warehouse",
+        back_populates="items",
+        uselist=False,
+    )

--- a/tests/noop/test_relation_group_map.py
+++ b/tests/noop/test_relation_group_map.py
@@ -1,0 +1,393 @@
+"""Test RelationGroupMap association fields with NoOpMateria."""
+
+from __future__ import annotations
+
+import pytest
+
+from arcanus.association import RelationGroupMap
+from tests.transmuters import GroupedCatalog, GroupedTag
+
+
+class TestRelationGroupMapBasics:
+    """Test basic RelationGroupMap field behaviour."""
+
+    def test_init_empty(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        assert isinstance(catalog.tags, RelationGroupMap)
+        assert len(catalog.tags) == 0
+
+    def test_init_with_values(self):
+        t1 = GroupedTag(id=1, name="python")
+        t2 = GroupedTag(id=2, name="rust")
+        t3 = GroupedTag(id=3, name="go")
+        catalog = GroupedCatalog(
+            id=1,
+            title="Test",
+            tags=RelationGroupMap({"lang": [t1, t2], "other": [t3]}),
+        )
+        assert isinstance(catalog.tags, RelationGroupMap)
+        assert len(catalog.tags) == 2
+        assert len(catalog.tags["lang"]) == 2
+        assert len(catalog.tags["other"]) == 1
+
+    def test_setitem(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        t = GroupedTag(id=1, name="python")
+        catalog.tags["lang"] = [t]
+        assert len(catalog.tags) == 1
+        assert catalog.tags["lang"][0] is t
+
+    def test_getitem(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        t = GroupedTag(id=1, name="python")
+        catalog.tags["lang"] = [t]
+        items = catalog.tags["lang"]
+        assert len(items) == 1
+        assert items[0].name == "python"
+
+    def test_getitem_missing_raises(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        with pytest.raises(KeyError):
+            catalog.tags["missing"]
+
+    def test_delitem(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        t = GroupedTag(id=1, name="python")
+        catalog.tags["lang"] = [t]
+        del catalog.tags["lang"]
+        assert len(catalog.tags) == 0
+
+    def test_delitem_missing_raises(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        with pytest.raises(KeyError):
+            del catalog.tags["missing"]
+
+    def test_get_present(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        t = GroupedTag(id=1, name="python")
+        catalog.tags["lang"] = [t]
+        result = catalog.tags.get("lang")
+        assert result is not None
+        assert len(result) == 1
+
+    def test_get_absent_default(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        assert catalog.tags.get("missing") is None
+        assert catalog.tags.get("missing", []) == []
+
+
+class TestRelationGroupMapAppendExtendRemove:
+    """Test the convenience methods: append, extend, remove_item, flat_values."""
+
+    def test_append_creates_group(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        t = GroupedTag(id=1, name="python")
+        catalog.tags.append("lang", t)
+        assert len(catalog.tags) == 1
+        assert len(catalog.tags["lang"]) == 1
+        assert catalog.tags["lang"][0] is t
+
+    def test_append_to_existing_group(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        t1 = GroupedTag(id=1, name="python")
+        t2 = GroupedTag(id=2, name="rust")
+        catalog.tags.append("lang", t1)
+        catalog.tags.append("lang", t2)
+        assert len(catalog.tags["lang"]) == 2
+
+    def test_extend(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        t1 = GroupedTag(id=1, name="python")
+        t2 = GroupedTag(id=2, name="rust")
+        catalog.tags.extend("lang", [t1, t2])
+        assert len(catalog.tags["lang"]) == 2
+
+    def test_extend_existing_group(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        t1 = GroupedTag(id=1, name="python")
+        t2 = GroupedTag(id=2, name="rust")
+        t3 = GroupedTag(id=3, name="go")
+        catalog.tags.append("lang", t1)
+        catalog.tags.extend("lang", [t2, t3])
+        assert len(catalog.tags["lang"]) == 3
+
+    def test_remove_item(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        t1 = GroupedTag(id=1, name="python")
+        t2 = GroupedTag(id=2, name="rust")
+        catalog.tags["lang"] = [t1, t2]
+        catalog.tags.remove_item("lang", t1)
+        assert len(catalog.tags["lang"]) == 1
+        assert catalog.tags["lang"][0] is t2
+
+    def test_remove_item_deletes_empty_group(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        t = GroupedTag(id=1, name="python")
+        catalog.tags["lang"] = [t]
+        catalog.tags.remove_item("lang", t)
+        assert "lang" not in catalog.tags
+        assert len(catalog.tags) == 0
+
+    def test_flat_values(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        t1 = GroupedTag(id=1, name="python")
+        t2 = GroupedTag(id=2, name="rust")
+        t3 = GroupedTag(id=3, name="go")
+        catalog.tags["lang"] = [t1, t2]
+        catalog.tags["other"] = [t3]
+        flat = catalog.tags.flat_values()
+        assert len(flat) == 3
+        names = {t.name for t in flat}
+        assert names == {"python", "rust", "go"}
+
+    def test_flat_values_empty(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        assert catalog.tags.flat_values() == []
+
+
+class TestRelationGroupMapDictOperations:
+    """Test dict operations: keys, values, items, pop, popitem, update, setdefault, clear, copy."""
+
+    def test_keys(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        catalog.tags["a"] = [GroupedTag(id=1, name="x")]
+        catalog.tags["b"] = [GroupedTag(id=2, name="y")]
+        assert set(catalog.tags.keys()) == {"a", "b"}
+
+    def test_values(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        t1 = GroupedTag(id=1, name="x")
+        catalog.tags["a"] = [t1]
+        vals = list(catalog.tags.values())
+        assert len(vals) == 1
+        assert len(vals[0]) == 1
+
+    def test_items(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        t1 = GroupedTag(id=1, name="x")
+        catalog.tags["a"] = [t1]
+        items = list(catalog.tags.items())
+        assert len(items) == 1
+        assert items[0][0] == "a"
+        assert len(items[0][1]) == 1
+
+    def test_pop(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        t = GroupedTag(id=1, name="x")
+        catalog.tags["a"] = [t]
+        result = catalog.tags.pop("a")
+        assert len(result) == 1
+        assert "a" not in catalog.tags
+
+    def test_pop_missing_raises(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        with pytest.raises(KeyError):
+            catalog.tags.pop("missing")
+
+    def test_pop_missing_with_default(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        result = catalog.tags.pop("missing", [])
+        assert result == []
+
+    def test_popitem(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        catalog.tags["a"] = [GroupedTag(id=1, name="x")]
+        key, items = catalog.tags.popitem()
+        assert key == "a"
+        assert len(items) == 1
+        assert len(catalog.tags) == 0
+
+    def test_update(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        t1 = GroupedTag(id=1, name="x")
+        t2 = GroupedTag(id=2, name="y")
+        catalog.tags.update({"a": [t1], "b": [t2]})
+        assert len(catalog.tags) == 2
+        assert len(catalog.tags["a"]) == 1
+        assert len(catalog.tags["b"]) == 1
+
+    def test_update_replaces_existing_key(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        t1 = GroupedTag(id=1, name="x")
+        t2 = GroupedTag(id=2, name="y")
+        catalog.tags["a"] = [t1]
+        catalog.tags.update({"a": [t2]})
+        assert len(catalog.tags["a"]) == 1
+        assert catalog.tags["a"][0].name == "y"
+
+    def test_setdefault_absent(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        t = GroupedTag(id=1, name="x")
+        result = catalog.tags.setdefault("a", [t])
+        assert len(result) == 1
+        assert "a" in catalog.tags
+
+    def test_setdefault_present(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        t1 = GroupedTag(id=1, name="x")
+        t2 = GroupedTag(id=2, name="y")
+        catalog.tags["a"] = [t1]
+        result = catalog.tags.setdefault("a", [t2])
+        assert len(result) == 1
+        assert result[0].name == "x"
+
+    def test_setdefault_no_default(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        result = catalog.tags.setdefault("a")
+        assert result == []
+        assert "a" in catalog.tags
+
+    def test_clear(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        catalog.tags["a"] = [GroupedTag(id=1, name="x")]
+        catalog.tags["b"] = [GroupedTag(id=2, name="y")]
+        catalog.tags.clear()
+        assert len(catalog.tags) == 0
+
+    def test_copy(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        t = GroupedTag(id=1, name="x")
+        catalog.tags["a"] = [t]
+        copied = catalog.tags.copy()
+        assert isinstance(copied, dict)
+        assert not isinstance(copied, RelationGroupMap)
+        assert list(copied.keys()) == ["a"]
+        assert len(copied["a"]) == 1
+
+
+class TestRelationGroupMapIteration:
+    """Test iteration, length, containment, bool."""
+
+    def test_iter(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        catalog.tags["a"] = [GroupedTag(id=1, name="x")]
+        catalog.tags["b"] = [GroupedTag(id=2, name="y")]
+        keys = list(catalog.tags)
+        assert set(keys) == {"a", "b"}
+
+    def test_len(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        assert len(catalog.tags) == 0
+        catalog.tags["a"] = [GroupedTag(id=1, name="x")]
+        assert len(catalog.tags) == 1
+
+    def test_contains(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        catalog.tags["a"] = [GroupedTag(id=1, name="x")]
+        assert "a" in catalog.tags
+        assert "b" not in catalog.tags
+
+    def test_bool_empty(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        assert not catalog.tags
+
+    def test_bool_nonempty(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        catalog.tags["a"] = [GroupedTag(id=1, name="x")]
+        assert catalog.tags
+
+    def test_reversed(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        catalog.tags["a"] = [GroupedTag(id=1, name="x")]
+        catalog.tags["b"] = [GroupedTag(id=2, name="y")]
+        keys = list(reversed(catalog.tags))
+        assert keys == ["b", "a"]
+
+
+class TestRelationGroupMapComparisons:
+    """Test equality and merge operators."""
+
+    def test_eq_same(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        t = GroupedTag(id=1, name="x")
+        catalog.tags["a"] = [t]
+        assert catalog.tags == {"a": [t]}
+
+    def test_eq_different(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        t = GroupedTag(id=1, name="x")
+        catalog.tags["a"] = [t]
+        assert catalog.tags != {"b": [t]}
+
+    def test_ne(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        assert catalog.tags != {"a": []}
+
+    def test_or_merge(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        t1 = GroupedTag(id=1, name="x")
+        t2 = GroupedTag(id=2, name="y")
+        catalog.tags["a"] = [t1]
+        result = catalog.tags | {"b": [t2]}
+        assert set(result.keys()) == {"a", "b"}
+        assert isinstance(result, dict)
+
+    def test_ior_merge(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        t1 = GroupedTag(id=1, name="x")
+        t2 = GroupedTag(id=2, name="y")
+        catalog.tags["a"] = [t1]
+        tags = catalog.tags
+        tags |= {"b": [t2]}
+        assert len(catalog.tags) == 2
+
+
+class TestRelationGroupMapSerialization:
+    """Test model_dump and model_dump_json."""
+
+    def test_model_dump(self):
+        t = GroupedTag(id=1, name="x")
+        catalog = GroupedCatalog(
+            id=1,
+            title="Test",
+            tags=RelationGroupMap({"a": [t]}),
+        )
+        data = catalog.model_dump()
+        assert "tags" in data
+        assert "a" in data["tags"]
+        assert len(data["tags"]["a"]) == 1
+        assert data["tags"]["a"][0]["name"] == "x"
+
+    def test_model_dump_empty(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        data = catalog.model_dump()
+        assert data["tags"] == {}
+
+
+class TestRelationGroupMapRepr:
+    """Test __repr__ and __str__."""
+
+    def test_repr_empty(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        r = repr(catalog.tags)
+        assert "RelationGroupMap" in r
+        assert "GroupedTag" in r
+
+    def test_str(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        t = GroupedTag(id=1, name="x")
+        catalog.tags["a"] = [t]
+        s = str(catalog.tags)
+        assert "a" in s
+
+
+class TestRelationGroupMapIsolation:
+    """Test that different instances don't share state."""
+
+    def test_separate_instances(self):
+        c1 = GroupedCatalog(id=1, title="A")
+        c2 = GroupedCatalog(id=2, title="B")
+        t = GroupedTag(id=1, name="x")
+        c1.tags["a"] = [t]
+        assert len(c1.tags) == 1
+        assert len(c2.tags) == 0
+
+    def test_multiple_items_same_key(self):
+        catalog = GroupedCatalog(id=1, title="Test")
+        t1 = GroupedTag(id=1, name="x")
+        t2 = GroupedTag(id=2, name="y")
+        t3 = GroupedTag(id=3, name="z")
+        catalog.tags["lang"] = [t1, t2, t3]
+        assert len(catalog.tags["lang"]) == 3
+        names = [t.name for t in catalog.tags["lang"]]
+        assert names == ["x", "y", "z"]

--- a/tests/noop/test_relation_group_map.py
+++ b/tests/noop/test_relation_group_map.py
@@ -77,7 +77,7 @@ class TestRelationGroupMapBasics:
 
 
 class TestRelationGroupMapAppendExtendRemove:
-    """Test the convenience methods: append, extend, remove_item, flat_values."""
+    """Test the convenience methods: append, extend, discard, flatten."""
 
     def test_append_creates_group(self):
         catalog = GroupedCatalog(id=1, title="Test")
@@ -111,38 +111,38 @@ class TestRelationGroupMapAppendExtendRemove:
         catalog.tags.extend("lang", [t2, t3])
         assert len(catalog.tags["lang"]) == 3
 
-    def test_remove_item(self):
+    def test_discard(self):
         catalog = GroupedCatalog(id=1, title="Test")
         t1 = GroupedTag(id=1, name="python")
         t2 = GroupedTag(id=2, name="rust")
         catalog.tags["lang"] = [t1, t2]
-        catalog.tags.remove_item("lang", t1)
+        catalog.tags.discard("lang", t1)
         assert len(catalog.tags["lang"]) == 1
         assert catalog.tags["lang"][0] is t2
 
-    def test_remove_item_deletes_empty_group(self):
+    def test_discard_deletes_empty_group(self):
         catalog = GroupedCatalog(id=1, title="Test")
         t = GroupedTag(id=1, name="python")
         catalog.tags["lang"] = [t]
-        catalog.tags.remove_item("lang", t)
+        catalog.tags.discard("lang", t)
         assert "lang" not in catalog.tags
         assert len(catalog.tags) == 0
 
-    def test_flat_values(self):
+    def test_flatten(self):
         catalog = GroupedCatalog(id=1, title="Test")
         t1 = GroupedTag(id=1, name="python")
         t2 = GroupedTag(id=2, name="rust")
         t3 = GroupedTag(id=3, name="go")
         catalog.tags["lang"] = [t1, t2]
         catalog.tags["other"] = [t3]
-        flat = catalog.tags.flat_values()
+        flat = catalog.tags.flatten()
         assert len(flat) == 3
         names = {t.name for t in flat}
         assert names == {"python", "rust", "go"}
 
-    def test_flat_values_empty(self):
+    def test_flatten_empty(self):
         catalog = GroupedCatalog(id=1, title="Test")
-        assert catalog.tags.flat_values() == []
+        assert catalog.tags.flatten() == []
 
 
 class TestRelationGroupMapDictOperations:

--- a/tests/sqlalchemy/sync/test_relation_group_map.py
+++ b/tests/sqlalchemy/sync/test_relation_group_map.py
@@ -1,0 +1,484 @@
+"""Test RelationGroupMap association with SQLAlchemy Materia.
+
+Tests:
+- CRUD operations with grouped dict relationships (Warehouse <-> WarehouseItem via attribute_keyed_list_dict)
+- Lazy and eager loading of grouped dict relationships
+- Serialization after ORM load
+- Dict mutation operations persisted through SQLAlchemy
+- Convenience methods: append, extend, remove_item, flat_values
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import Engine, select
+from sqlalchemy.orm import selectinload
+
+from arcanus.association import RelationGroupMap
+from arcanus.materia.sqlalchemy import Session
+from tests.transmuters import Warehouse, WarehouseItem
+
+
+class TestRelationGroupMapCRUD:
+    """Test basic CRUD operations with grouped dict relationships."""
+
+    def test_create_warehouse_with_items(self, engine: Engine):
+        """Test creating a Warehouse with WarehouseItems through RelationGroupMap."""
+        with Session(engine) as session:
+            wh = Warehouse(name="Main")
+            item1 = WarehouseItem(category="tools", name="Hammer", quantity=10)
+            item2 = WarehouseItem(category="tools", name="Wrench", quantity=5)
+            item3 = WarehouseItem(category="parts", name="Bolt", quantity=100)
+            wh.items["tools"] = [item1, item2]
+            wh.items["parts"] = [item3]
+
+            session.add(wh)
+            session.flush()
+            wh.revalidate()
+            item1.revalidate()
+            item2.revalidate()
+            item3.revalidate()
+
+            assert wh.id is not None
+            assert item1.id is not None
+            assert item2.id is not None
+            assert item3.id is not None
+            assert len(wh.items) == 2
+            assert len(wh.items["tools"]) == 2
+            assert len(wh.items["parts"]) == 1
+
+    def test_create_warehouse_empty(self, engine: Engine):
+        """Test creating a Warehouse with no items."""
+        with Session(engine) as session:
+            wh = Warehouse(name="Empty")
+            session.add(wh)
+            session.flush()
+            wh.revalidate()
+
+            assert wh.id is not None
+            assert len(wh.items) == 0
+
+    def test_append_item(self, engine: Engine):
+        """Test appending a single item to a group."""
+        with Session(engine) as session:
+            wh = Warehouse(name="Append Test")
+            session.add(wh)
+            session.flush()
+
+            item = WarehouseItem(category="tools", name="Drill", quantity=3)
+            wh.items.append("tools", item)
+            session.flush()
+            item.revalidate()
+
+            assert item.id is not None
+            assert len(wh.items["tools"]) == 1
+
+    def test_append_multiple_same_key(self, engine: Engine):
+        """Test appending multiple items to the same key."""
+        with Session(engine) as session:
+            wh = Warehouse(name="Multi Append")
+            session.add(wh)
+            session.flush()
+
+            wh.items.append(
+                "tools", WarehouseItem(category="tools", name="Saw", quantity=2)
+            )
+            wh.items.append(
+                "tools", WarehouseItem(category="tools", name="Drill", quantity=1)
+            )
+            wh.items.append(
+                "tools", WarehouseItem(category="tools", name="Level", quantity=1)
+            )
+            session.flush()
+
+            assert len(wh.items["tools"]) == 3
+
+    def test_remove_item_from_group(self, engine: Engine):
+        """Test removing a single item from a group."""
+        with Session(engine) as session:
+            wh = Warehouse(name="Remove Test")
+            item1 = WarehouseItem(category="tools", name="Hammer", quantity=10)
+            item2 = WarehouseItem(category="tools", name="Wrench", quantity=5)
+            wh.items["tools"] = [item1, item2]
+            session.add(wh)
+            session.flush()
+
+            assert len(wh.items["tools"]) == 2
+            wh.items.remove_item("tools", item1)
+            session.flush()
+
+            assert len(wh.items["tools"]) == 1
+            assert wh.items["tools"][0].name == "Wrench"
+
+    def test_remove_last_item_deletes_key(self, engine: Engine):
+        """Test removing the last item from a group deletes the key."""
+        with Session(engine) as session:
+            wh = Warehouse(name="Remove Last")
+            item = WarehouseItem(category="tools", name="Hammer", quantity=1)
+            wh.items["tools"] = [item]
+            session.add(wh)
+            session.flush()
+
+            wh.items.remove_item("tools", item)
+            session.flush()
+
+            assert "tools" not in wh.items
+            assert len(wh.items) == 0
+
+    def test_delete_group(self, engine: Engine):
+        """Test deleting an entire group."""
+        with Session(engine) as session:
+            wh = Warehouse(name="Delete Group")
+            wh.items["tools"] = [
+                WarehouseItem(category="tools", name="Hammer", quantity=10),
+                WarehouseItem(category="tools", name="Wrench", quantity=5),
+            ]
+            wh.items["parts"] = [
+                WarehouseItem(category="parts", name="Bolt", quantity=100),
+            ]
+            session.add(wh)
+            session.flush()
+
+            assert len(wh.items) == 2
+            del wh.items["tools"]
+            session.flush()
+
+            assert len(wh.items) == 1
+            assert "parts" in wh.items
+
+    def test_clear_all(self, engine: Engine):
+        """Test clearing all groups."""
+        with Session(engine) as session:
+            wh = Warehouse(name="Clear All")
+            for cat in ["tools", "parts", "misc"]:
+                wh.items[cat] = [
+                    WarehouseItem(category=cat, name=f"{cat} item", quantity=1)
+                ]
+            session.add(wh)
+            session.flush()
+
+            assert len(wh.items) == 3
+            wh.items.clear()
+            session.flush()
+
+            assert len(wh.items) == 0
+
+
+class TestRelationGroupMapLoading:
+    """Test lazy and eager loading of grouped dict relationships."""
+
+    def test_lazy_load_items(self, engine: Engine):
+        """Test that items are lazily loaded when accessed."""
+        with Session(engine) as session:
+            wh = Warehouse(name="Lazy Load")
+            wh.items["tools"] = [
+                WarehouseItem(category="tools", name="Hammer", quantity=10),
+                WarehouseItem(category="tools", name="Wrench", quantity=5),
+            ]
+            wh.items["parts"] = [
+                WarehouseItem(category="parts", name="Bolt", quantity=100),
+            ]
+            session.add(wh)
+            session.flush()
+            wh.revalidate()
+            wh_id = wh.id
+            session.commit()
+
+        with Session(engine) as session:
+            stmt = select(Warehouse).where(Warehouse["id"] == wh_id)
+            wh = session.scalars(stmt).unique().one()
+            assert isinstance(wh, Warehouse)
+            assert isinstance(wh.items, RelationGroupMap)
+
+            # Accessing items triggers lazy load
+            assert len(wh.items) == 2
+            assert len(wh.items["tools"]) == 2
+            assert len(wh.items["parts"]) == 1
+
+    def test_eager_load_selectinload(self, engine: Engine):
+        """Test eager loading items with selectinload."""
+        with Session(engine) as session:
+            wh = Warehouse(name="Eager Load")
+            wh.items["tools"] = [
+                WarehouseItem(category="tools", name="Drill", quantity=3),
+            ]
+            wh.items["parts"] = [
+                WarehouseItem(category="parts", name="Nut", quantity=50),
+                WarehouseItem(category="parts", name="Washer", quantity=200),
+            ]
+            session.add(wh)
+            session.flush()
+            wh.revalidate()
+            wh_id = wh.id
+            session.commit()
+
+        with Session(engine) as session:
+            stmt = (
+                select(Warehouse)
+                .where(Warehouse["id"] == wh_id)
+                .options(selectinload(Warehouse["items"]))
+            )
+            wh = session.scalars(stmt).unique().one()
+            assert isinstance(wh, Warehouse)
+            assert len(wh.items) == 2
+            assert len(wh.items["tools"]) == 1
+            assert len(wh.items["parts"]) == 2
+
+    def test_load_preserves_grouping(self, engine: Engine):
+        """Test that grouping keys are preserved after loading from DB."""
+        with Session(engine) as session:
+            wh = Warehouse(name="Preserved Grouping")
+            for cat in ["alpha", "beta", "gamma"]:
+                wh.items[cat] = [
+                    WarehouseItem(category=cat, name=f"{cat}1", quantity=1),
+                    WarehouseItem(category=cat, name=f"{cat}2", quantity=2),
+                ]
+            session.add(wh)
+            session.flush()
+            wh.revalidate()
+            wh_id = wh.id
+            session.commit()
+
+        with Session(engine) as session:
+            stmt = select(Warehouse).where(Warehouse["id"] == wh_id)
+            wh = session.scalars(stmt).unique().one()
+            assert set(wh.items.keys()) == {"alpha", "beta", "gamma"}
+            for cat in ["alpha", "beta", "gamma"]:
+                assert len(wh.items[cat]) == 2
+
+
+class TestRelationGroupMapSerialization:
+    """Test serialization of RelationGroupMap after ORM operations."""
+
+    def test_model_dump_after_create(self, engine: Engine):
+        """Test model_dump after creating warehouse with grouped items."""
+        with Session(engine) as session:
+            wh = Warehouse(name="Dump Warehouse")
+            wh.items["tools"] = [
+                WarehouseItem(category="tools", name="Hammer", quantity=10),
+                WarehouseItem(category="tools", name="Wrench", quantity=5),
+            ]
+            session.add(wh)
+            session.flush()
+
+            data = wh.model_dump()
+            assert isinstance(data["items"], dict)
+            assert "tools" in data["items"]
+            assert len(data["items"]["tools"]) == 2
+
+    def test_model_dump_after_load(self, engine: Engine):
+        """Test model_dump after loading from DB with selectinload."""
+        with Session(engine) as session:
+            wh = Warehouse(name="Load Dump Warehouse")
+            wh.items["parts"] = [
+                WarehouseItem(category="parts", name="Bolt", quantity=100),
+            ]
+            session.add(wh)
+            session.flush()
+            wh.revalidate()
+            wh_id = wh.id
+            session.commit()
+
+        with Session(engine) as session:
+            stmt = (
+                select(Warehouse)
+                .where(Warehouse["id"] == wh_id)
+                .options(selectinload(Warehouse["items"]))
+            )
+            wh = session.scalars(stmt).unique().one()
+            data = wh.model_dump()
+            assert isinstance(data["items"], dict)
+            assert "parts" in data["items"]
+            assert len(data["items"]["parts"]) == 1
+            assert data["items"]["parts"][0]["name"] == "Bolt"
+
+    def test_model_dump_empty(self, engine: Engine):
+        """Test model_dump with empty items."""
+        with Session(engine) as session:
+            wh = Warehouse(name="Empty Dump Warehouse")
+            session.add(wh)
+            session.flush()
+
+            data = wh.model_dump()
+            assert data["items"] == {}
+
+
+class TestRelationGroupMapDictOperations:
+    """Test dict operations through the ORM."""
+
+    def test_get_existing_key(self, engine: Engine):
+        """Test get() on a loaded warehouse."""
+        with Session(engine) as session:
+            wh = Warehouse(name="Get Warehouse")
+            wh.items["tools"] = [
+                WarehouseItem(category="tools", name="Hammer", quantity=10),
+            ]
+            session.add(wh)
+            session.flush()
+
+            result = wh.items.get("tools")
+            assert result is not None
+            assert len(result) == 1
+            assert wh.items.get("missing") is None
+
+    def test_pop_group(self, engine: Engine):
+        """Test pop() removes and returns the group."""
+        with Session(engine) as session:
+            wh = Warehouse(name="Pop Warehouse")
+            wh.items["tools"] = [
+                WarehouseItem(category="tools", name="Hammer", quantity=10),
+                WarehouseItem(category="tools", name="Wrench", quantity=5),
+            ]
+            session.add(wh)
+            session.flush()
+
+            items = wh.items.pop("tools")
+            assert len(items) == 2
+            assert len(wh.items) == 0
+
+    def test_keys_values_items(self, engine: Engine):
+        """Test keys(), values(), items() views."""
+        with Session(engine) as session:
+            wh = Warehouse(name="Views Warehouse")
+            wh.items["tools"] = [
+                WarehouseItem(category="tools", name="Hammer", quantity=10),
+            ]
+            wh.items["parts"] = [
+                WarehouseItem(category="parts", name="Bolt", quantity=100),
+            ]
+            session.add(wh)
+            session.flush()
+
+            assert set(wh.items.keys()) == {"tools", "parts"}
+            assert len(list(wh.items.values())) == 2
+            assert len(list(wh.items.items())) == 2
+
+    def test_contains_key(self, engine: Engine):
+        """Test key membership check."""
+        with Session(engine) as session:
+            wh = Warehouse(name="Contains Warehouse")
+            wh.items["tools"] = [
+                WarehouseItem(category="tools", name="Hammer", quantity=10),
+            ]
+            session.add(wh)
+            session.flush()
+
+            assert "tools" in wh.items
+            assert "gone" not in wh.items
+
+    def test_flat_values(self, engine: Engine):
+        """Test flat_values() returns all items across all groups."""
+        with Session(engine) as session:
+            wh = Warehouse(name="Flat Warehouse")
+            wh.items["tools"] = [
+                WarehouseItem(category="tools", name="Hammer", quantity=10),
+                WarehouseItem(category="tools", name="Wrench", quantity=5),
+            ]
+            wh.items["parts"] = [
+                WarehouseItem(category="parts", name="Bolt", quantity=100),
+            ]
+            session.add(wh)
+            session.flush()
+
+            flat = wh.items.flat_values()
+            assert len(flat) == 3
+            names = {item.name for item in flat}
+            assert names == {"Hammer", "Wrench", "Bolt"}
+
+    def test_extend_group(self, engine: Engine):
+        """Test extend() adds multiple items to a group."""
+        with Session(engine) as session:
+            wh = Warehouse(name="Extend Warehouse")
+            wh.items["tools"] = [
+                WarehouseItem(category="tools", name="Hammer", quantity=10),
+            ]
+            session.add(wh)
+            session.flush()
+
+            wh.items.extend(
+                "tools",
+                [
+                    WarehouseItem(category="tools", name="Wrench", quantity=5),
+                    WarehouseItem(category="tools", name="Drill", quantity=3),
+                ],
+            )
+            session.flush()
+
+            assert len(wh.items["tools"]) == 3
+
+    def test_update_groups(self, engine: Engine):
+        """Test update() with a mapping of groups."""
+        with Session(engine) as session:
+            wh = Warehouse(name="Update Warehouse")
+            session.add(wh)
+            session.flush()
+
+            wh.items.update(
+                {
+                    "tools": [
+                        WarehouseItem(category="tools", name="Hammer", quantity=10)
+                    ],
+                    "parts": [
+                        WarehouseItem(category="parts", name="Bolt", quantity=100)
+                    ],
+                }
+            )
+            session.flush()
+
+            assert len(wh.items) == 2
+            assert len(wh.items["tools"]) == 1
+            assert len(wh.items["parts"]) == 1
+
+
+class TestRelationGroupMapPersistence:
+    """Test that mutations are persisted across sessions."""
+
+    def test_append_persists(self, engine: Engine):
+        """Test that appended items are visible in a new session."""
+        with Session(engine) as session:
+            wh = Warehouse(name="Persist Append")
+            session.add(wh)
+            session.flush()
+
+            wh.items.append(
+                "tools", WarehouseItem(category="tools", name="Hammer", quantity=10)
+            )
+            wh.items.append(
+                "tools", WarehouseItem(category="tools", name="Wrench", quantity=5)
+            )
+            session.flush()
+            wh.revalidate()
+            wh_id = wh.id
+            session.commit()
+
+        with Session(engine) as session:
+            stmt = select(Warehouse).where(Warehouse["id"] == wh_id)
+            wh = session.scalars(stmt).unique().one()
+            assert len(wh.items["tools"]) == 2
+            names = {item.name for item in wh.items["tools"]}
+            assert names == {"Hammer", "Wrench"}
+
+    def test_multiple_groups_persist(self, engine: Engine):
+        """Test that multiple groups are persisted correctly."""
+        with Session(engine) as session:
+            wh = Warehouse(name="Persist Multi")
+            wh.items["tools"] = [
+                WarehouseItem(category="tools", name="Hammer", quantity=10),
+                WarehouseItem(category="tools", name="Wrench", quantity=5),
+            ]
+            wh.items["parts"] = [
+                WarehouseItem(category="parts", name="Bolt", quantity=100),
+                WarehouseItem(category="parts", name="Nut", quantity=200),
+                WarehouseItem(category="parts", name="Washer", quantity=300),
+            ]
+            session.add(wh)
+            session.flush()
+            wh.revalidate()
+            wh_id = wh.id
+            session.commit()
+
+        with Session(engine) as session:
+            stmt = select(Warehouse).where(Warehouse["id"] == wh_id)
+            wh = session.scalars(stmt).unique().one()
+            assert set(wh.items.keys()) == {"tools", "parts"}
+            assert len(wh.items["tools"]) == 2
+            assert len(wh.items["parts"]) == 3

--- a/tests/sqlalchemy/sync/test_relation_group_map.py
+++ b/tests/sqlalchemy/sync/test_relation_group_map.py
@@ -5,7 +5,7 @@ Tests:
 - Lazy and eager loading of grouped dict relationships
 - Serialization after ORM load
 - Dict mutation operations persisted through SQLAlchemy
-- Convenience methods: append, extend, remove_item, flat_values
+- Convenience methods: append, extend, discard, flatten
 """
 
 from __future__ import annotations
@@ -92,7 +92,7 @@ class TestRelationGroupMapCRUD:
 
             assert len(wh.items["tools"]) == 3
 
-    def test_remove_item_from_group(self, engine: Engine):
+    def test_discard_from_group(self, engine: Engine):
         """Test removing a single item from a group."""
         with Session(engine) as session:
             wh = Warehouse(name="Remove Test")
@@ -103,7 +103,7 @@ class TestRelationGroupMapCRUD:
             session.flush()
 
             assert len(wh.items["tools"]) == 2
-            wh.items.remove_item("tools", item1)
+            wh.items.discard("tools", item1)
             session.flush()
 
             assert len(wh.items["tools"]) == 1
@@ -118,7 +118,7 @@ class TestRelationGroupMapCRUD:
             session.add(wh)
             session.flush()
 
-            wh.items.remove_item("tools", item)
+            wh.items.discard("tools", item)
             session.flush()
 
             assert "tools" not in wh.items
@@ -365,8 +365,8 @@ class TestRelationGroupMapDictOperations:
             assert "tools" in wh.items
             assert "gone" not in wh.items
 
-    def test_flat_values(self, engine: Engine):
-        """Test flat_values() returns all items across all groups."""
+    def test_flatten(self, engine: Engine):
+        """Test flatten() returns all items across all groups."""
         with Session(engine) as session:
             wh = Warehouse(name="Flat Warehouse")
             wh.items["tools"] = [
@@ -379,7 +379,7 @@ class TestRelationGroupMapDictOperations:
             session.add(wh)
             session.flush()
 
-            flat = wh.items.flat_values()
+            flat = wh.items.flatten()
             assert len(flat) == 3
             names = {item.name for item in flat}
             assert names == {"Hammer", "Wrench", "Bolt"}

--- a/tests/transmuters.py
+++ b/tests/transmuters.py
@@ -7,14 +7,16 @@ from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import TypedDict
 
 from arcanus.association import (
+    GroupedRelationship,
+    MappedRelationship,
     Relation,
     RelationCollection,
+    RelationGroupMap,
     RelationMap,
-    RelationMaps,
     Relationship,
     Relationships,
     TypedRelationMap,
-    TypedRelationMaps,
+    TypedRelationship,
 )
 from arcanus.base import BaseTransmuter, Identity, Transmuter
 from arcanus.dataclass import dataclass
@@ -254,7 +256,7 @@ class Shelf(TestIdMixin, BaseTransmuter):
     id: Annotated[Optional[int], Identity] = Field(default=None, frozen=True)
     name: str
 
-    items: RelationMap[str, ShelfItem] = RelationMaps()
+    items: RelationMap[str, ShelfItem] = MappedRelationship()
 
 
 # Unblessed transmuters for noop RelationMap tests
@@ -275,7 +277,7 @@ class Catalog(BaseTransmuter):
     id: Annotated[Optional[int], Identity] = Field(default=None)
     title: str
 
-    tags: RelationMap[str, Tag] = RelationMaps()
+    tags: RelationMap[str, Tag] = MappedRelationship()
 
 
 class LabeledCatalog(BaseTransmuter):
@@ -286,7 +288,7 @@ class LabeledCatalog(BaseTransmuter):
     id: Annotated[Optional[int], Identity] = Field(default=None)
     title: str
 
-    tags: RelationMap[Literal["python", "rust", "go"], Tag] = RelationMaps()
+    tags: RelationMap[Literal["python", "rust", "go"], Tag] = MappedRelationship()
 
 
 class AuthorFlat(BaseTransmuter):
@@ -450,7 +452,7 @@ class Gallery(TestIdMixin, BaseTransmuter):
     id: Annotated[Optional[int], Identity] = Field(default=None, frozen=True)
     name: str
 
-    media: TypedRelationMap[DocumentMedia] = TypedRelationMaps()
+    media: TypedRelationMap[DocumentMedia] = TypedRelationship()
 
 
 class OptionalGallery(TestIdMixin, BaseTransmuter):
@@ -461,7 +463,7 @@ class OptionalGallery(TestIdMixin, BaseTransmuter):
     id: Annotated[Optional[int], Identity] = Field(default=None, frozen=True)
     name: str
 
-    media: TypedRelationMap[OptionalDocumentMedia] = TypedRelationMaps()
+    media: TypedRelationMap[OptionalDocumentMedia] = TypedRelationship()
 
 
 @sqlalchemy_materia.bless(models.BlogAuthor)
@@ -499,3 +501,51 @@ class BlogPost(TestIdMixin, BaseTransmuter):
     # Normal associations
     author: Relation[BlogAuthor] = Relationship()
     tags: RelationCollection[BlogTag] = Relationships()
+
+
+# ── RelationGroupMap test transmuters ──
+
+
+# SQLAlchemy-blessed transmuters
+@sqlalchemy_materia.bless(models.WarehouseItem)
+class WarehouseItem(TestIdMixin, BaseTransmuter):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: Annotated[Optional[int], Identity] = Field(default=None, frozen=True)
+    category: str
+    name: str
+    quantity: int = 0
+    warehouse_id: int | None = None
+
+    warehouse: Relation[Warehouse] = Relationship()
+
+
+@sqlalchemy_materia.bless(models.Warehouse)
+class Warehouse(TestIdMixin, BaseTransmuter):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: Annotated[Optional[int], Identity] = Field(default=None, frozen=True)
+    name: str
+
+    items: RelationGroupMap[str, WarehouseItem] = GroupedRelationship()
+
+
+# Unblessed transmuters for noop RelationGroupMap tests
+class GroupedTag(BaseTransmuter):
+    """Tag model used as value in grouped dict."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: Annotated[Optional[int], Identity] = Field(default=None)
+    name: str
+
+
+class GroupedCatalog(BaseTransmuter):
+    """Catalog with grouped dict-based tag mapping."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: Annotated[Optional[int], Identity] = Field(default=None)
+    title: str
+
+    tags: RelationGroupMap[str, GroupedTag] = GroupedRelationship()


### PR DESCRIPTION
## Summary

Introduces `RelationGroupMap[K, T]` — a new dict-based association type that produces `dict[K, list[T]]`, solving the problem where `RelationMap[K, T]`'s underlying `attribute_keyed_dict` silently drops duplicate keys.

**Motivation:** In relationships where multiple ORM objects share the same key value (e.g. multiple generated files with `role="primary_content"`), `RelationMap` keeps only one value per key. `RelationGroupMap` groups all values under the same key into a list, preserving every item.

---

## What's New

### `RelationGroupMap[K, T]` (association type)

A full `dict[K, list[T]]` association with:

- **Complete dict API** — `__getitem__`, `__setitem__`, `__delitem__`, `get`, `keys`, `values`, `items`, `pop`, `popitem`, `update`, `setdefault`, `clear`, `copy`, `__contains__`, `__eq__`, `__ne__`, `__or__`, `__ior__`, `__reversed__`, `__len__`, `__bool__`, `__iter__`
- **Lazy loading** via `@ensure_loaded` decorator, with both sync (`_load`) and async (`_aload`) paths
- **Type validation** via Pydantic `TypeAdapter` — keys and values are blessed/coerced on write
- **SQLAlchemy integration** — reads from/writes to `__provided__` (`KeyFuncListDict`) with proper ORM event propagation
- **Pydantic core schema** — custom `__get_pydantic_core_schema__` / `__get_pydantic_serialize_schema__` for validation and serialization
- **Convenience methods**:
  - `append(key, value)` — add a single item to a group, creating the group if needed
  - `extend(key, values)` — add multiple items to a group
  - `remove_item(key, value)` — remove a single item from a group (removes the key if the list becomes empty)
  - `flat_values()` — return all values across all keys as a flat list

### `KeyFuncListDict` (SQLAlchemy collection class)

A custom `dict`-based SQLAlchemy collection in `arcanus/materia/sqlalchemy/collections.py` that:

- Groups ORM objects by a key function into `dict[str, list[ORM]]`
- Implements `@collection.appender`, `@collection.remover`, `@collection.iterator` for proper SQLAlchemy instrumentation
- Correctly handles individual item removal (avoids `AttributeError: 'list' object has no attribute '_sa_instance_state'` that would occur with naive `dict.clear()`)

### `attribute_keyed_list_dict(attr_name)` (factory)

Drop-in replacement for SQLAlchemy's `attribute_keyed_dict` when multiple rows may share the same key value:

```python
relationship(
    "ArticleGeneratedFile",
    collection_class=attribute_keyed_list_dict("role"),
    ...
)
```

### `GroupedRelationship` (field factory)

```python
class Article(BaseTransmuter):
    generated_files: RelationGroupMap[str, File] = GroupedRelationship()
```

### Factory Renames

Renamed factory functions for clarity (old names were confusing — e.g. "RelationMaps" sounded like "multiple maps"):

| Old Name | New Name |
|---|---|
| `RelationMaps` | `MappedRelationship` |
| `RelationGroupMaps` | `GroupedRelationship` |
| `TypedRelationMaps` | `TypedRelationship` |

Old names are preserved as backward-compatible aliases with `@deprecated` decorator from `typing_extensions`.

---

## Files Changed

| File | Change |
|---|---|
| `arcanus/materia/sqlalchemy/collections.py` | **New** — `KeyFuncListDict` + `attribute_keyed_list_dict` factory |
| `arcanus/association.py` | `RelationGroupMap` class (~400 lines), factory renames, deprecated aliases |
| `arcanus/__init__.py` | New exports: `RelationGroupMap`, `GroupedRelationship`, `MappedRelationship`, `TypedRelationship` |
| `arcanus/materia/sqlalchemy/__init__.py` | Export `attribute_keyed_list_dict` |
| `tests/models.py` | `Warehouse` + `WarehouseItem` ORM models using `attribute_keyed_list_dict("category")` |
| `tests/transmuters.py` | Blessed `Warehouse`/`WarehouseItem` + unblessed `GroupedCatalog`/`GroupedTag` transmuters |
| `tests/noop/test_relation_group_map.py` | **New** — 48 tests (basics, append/extend/remove, dict ops, iteration, comparisons, serialization, repr, isolation) |
| `tests/sqlalchemy/sync/test_relation_group_map.py` | **New** — 23 tests (CRUD, lazy/eager loading, serialization, dict operations, persistence) |
| `README.md` | Updated factory names in documentation |

---

## Test Results

```
770 passed, 1 skipped
```

All existing tests continue to pass. The 3 deprecation warnings are expected — they come from existing tests that still use the old factory names (`RelationMaps`, `TypedRelationMaps`).