### PR TITLE
fix: support association_proxy over attribute_keyed_list_dict in RelationGroupMap

### DIFF
--- a/arcanus/association.py
+++ b/arcanus/association.py
@@ -1554,9 +1554,15 @@ class RelationGroupMap(dict[K, list[T]], Association[T]):
         super().__init__()
         self.__instance__ = None
         self.__loaded__ = False
+        self.__backing_attr__ = None
         self.__payloads__: dict[K, list[T]] = (
             {k: list(v) for k, v in payloads.items()} if payloads else {}
         )
+
+    # When the transmuter field maps to an association proxy (not the underlying
+    # relationship directly), the materia can set this to the underlying
+    # collection name so mutations go through the real collection class.
+    __backing_attr__: str | None
 
     @property
     def __provided__(self) -> Any | None:
@@ -1565,7 +1571,8 @@ class RelationGroupMap(dict[K, list[T]], Association[T]):
         # it would be a KeyFuncListDict.
         if not self.__instance_provider__:
             return None
-        return getattr(self.__instance_provider__, self.used_name)
+        attr = self.__backing_attr__ or self.used_name
+        return getattr(self.__instance_provider__, attr)
 
     @cached_property
     def __validator__(self) -> TypeAdapter[T]:
@@ -1654,22 +1661,22 @@ class RelationGroupMap(dict[K, list[T]], Association[T]):
         if self.__loaded__:
             return self
 
-        active_materia.get().load_association(self)
+        provided = active_materia.get().load_association(self)
 
         # A: No provided, None
         # B: provided value is empty, {}
-        if not self.__provided__:
+        if not provided:
             return self
 
-        # Remove payloads whose key is already in __provided__
+        # Remove payloads whose key is already in provided
         self.__payloads__ = {
-            k: v for k, v in self.__payloads__.items() if k not in self.__provided__
+            k: v for k, v in self.__payloads__.items() if k not in provided
         }
 
-        if len(self.__provided__) != super().__len__() or not super().__len__():
-            # Bless: __provided__ is a KeyFuncListDict (dict[K, list[ORM]])
+        if len(provided) != super().__len__() or not super().__len__():
+            # Bless: provided is a dict[K, list[ORM]] (e.g. KeyFuncListDict)
             super().clear()
-            for key, orm_list in self.__provided__.items():
+            for key, orm_list in provided.items():
                 super().__setitem__(key, self.bless_values(orm_list))
         self.__loaded__ = True
 

--- a/arcanus/materia/sqlalchemy/base.py
+++ b/arcanus/materia/sqlalchemy/base.py
@@ -147,7 +147,8 @@ class SqlalchemyMateria(BaseMateria):
                     association.__backing_attr__ = target_rel
 
                     mapper: Mapper = inspect(orm_class)  # type: ignore
-                    proxy_descriptor: AssociationProxy = mapper.all_orm_descriptors[used_name]  # type: ignore
+                    proxy_descriptor: AssociationProxy
+                    proxy_descriptor = mapper.all_orm_descriptors[used_name]  # type: ignore
                     value_attr = proxy_descriptor.value_attr
 
                     underlying = getattr(orm_instance, target_rel)

--- a/arcanus/materia/sqlalchemy/base.py
+++ b/arcanus/materia/sqlalchemy/base.py
@@ -7,10 +7,10 @@ from pydantic import ValidationInfo
 from sqlalchemy import inspect
 from sqlalchemy.exc import InvalidRequestError, MissingGreenlet
 from sqlalchemy.ext.associationproxy import AssociationProxy
-from sqlalchemy.orm import InstanceState
+from sqlalchemy.orm import InstanceState, Mapper
 from sqlalchemy.util import greenlet_spawn
 
-from arcanus.association import Association, DefferedAssociation
+from arcanus.association import Association, DefferedAssociation, RelationGroupMap
 from arcanus.base import Transmuter, TransmuterMetaclass
 from arcanus.materia.base import BaseMateria, T
 
@@ -130,9 +130,33 @@ class SqlalchemyMateria(BaseMateria):
                 f"The relation '{association.field_name}' is not yet prepared with an owner instance."
             )
         try:
-            return getattr(
-                association.__instance__.__transmuter_provided__, association.used_name
-            )
+            orm_instance = association.__instance__.__transmuter_provided__
+            used_name = association.used_name
+
+            # When a RelationGroupMap field maps to an association_proxy
+            # (e.g. proxy over a attribute_keyed_list_dict relationship),
+            # SQLAlchemy's _AssociationDict cannot iterate dict-of-lists
+            # values correctly.  Bypass the proxy and resolve manually:
+            # return a plain dict[K, list[target_ORM]] that the association
+            # can consume directly.
+            if isinstance(association, RelationGroupMap):
+                orm_class = type(orm_instance)
+                proxies = extract_association_proxies(orm_class)
+                if used_name in proxies:
+                    target_rel = proxies[used_name]
+                    association.__backing_attr__ = target_rel
+
+                    mapper: Mapper = inspect(orm_class)  # type: ignore
+                    proxy_descriptor: AssociationProxy = mapper.all_orm_descriptors[used_name]  # type: ignore
+                    value_attr = proxy_descriptor.value_attr
+
+                    underlying = getattr(orm_instance, target_rel)
+                    return {
+                        key: [getattr(item, value_attr) for item in items]
+                        for key, items in underlying.items()
+                    }
+
+            return getattr(orm_instance, used_name)
         except MissingGreenlet as missing_greenlet_error:
             association.__loaded__ = False
             raise MissingGreenlet(

--- a/tests/models.py
+++ b/tests/models.py
@@ -682,13 +682,45 @@ class BlogPost(Base):
 # ── RelationGroupMap test models ──
 
 
+class WarehouseManager(Base):
+    """Manager of a warehouse – used for association proxy testing."""
+
+    __tablename__ = "warehouse_manager"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+
+    warehouses: Mapped[list["Warehouse"]] = relationship(
+        "Warehouse",
+        back_populates="manager",
+        uselist=True,
+    )
+
+
 class Warehouse(Base):
-    """Warehouse with items grouped by category via attribute_keyed_list_dict."""
+    """Warehouse with items grouped by category via attribute_keyed_list_dict.
+
+    Also has a manager relationship with an association proxy for ``manager_name``
+    to test the combination of RelationGroupMap + association proxy.
+    """
 
     __tablename__ = "warehouse"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     name: Mapped[str] = mapped_column(String(200), nullable=False)
+
+    manager_id: Mapped[int | None] = mapped_column(
+        ForeignKey("warehouse_manager.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    manager: Mapped[WarehouseManager | None] = relationship(
+        "WarehouseManager",
+        back_populates="warehouses",
+        uselist=False,
+    )
+
+    # ── Association proxy ──
+    manager_name: AssociationProxy[str | None] = association_proxy("manager", "name")
 
     # Dict-of-lists relationship keyed by WarehouseItem.category
     items: Mapped[dict[str, list["WarehouseItem"]]] = relationship(
@@ -716,5 +748,77 @@ class WarehouseItem(Base):
     warehouse: Mapped[Warehouse] = relationship(
         "Warehouse",
         back_populates="items",
+        uselist=False,
+    )
+
+
+# ── Association proxy over attribute_keyed_list_dict test models ──
+
+
+class Article(Base):
+    """Article with generated files grouped by role via proxy over attribute_keyed_list_dict.
+
+    This models the pattern where an intermediate association table (ArticleGeneratedFile)
+    links Article to GeneratedFile via a role key, and an association_proxy provides
+    direct access to the files grouped by role.
+    """
+
+    __tablename__ = "article"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    title: Mapped[str] = mapped_column(String(200), nullable=False)
+
+    generated_file_associations: Mapped[dict[str, list["ArticleGeneratedFile"]]] = (
+        relationship(
+            "ArticleGeneratedFile",
+            collection_class=attribute_keyed_list_dict("role"),
+            cascade="all, delete-orphan",
+            back_populates="article",
+        )
+    )
+
+    generated_files: AssociationProxy[dict[str, list["GeneratedFile"]]] = (
+        association_proxy(
+            "generated_file_associations",
+            "file",
+            creator=lambda role, f: ArticleGeneratedFile(role=role, file=f),
+        )
+    )
+
+
+class GeneratedFile(Base):
+    """A generated file that can be associated with an article through a role."""
+
+    __tablename__ = "generated_file"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    filename: Mapped[str] = mapped_column(String(200), nullable=False)
+    size: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+
+class ArticleGeneratedFile(Base):
+    """Association between Article and GeneratedFile, keyed by role."""
+
+    __tablename__ = "article_generated_file"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    role: Mapped[str] = mapped_column(String(100), nullable=False)
+
+    article_id: Mapped[int] = mapped_column(
+        ForeignKey("article.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    article: Mapped[Article] = relationship(
+        "Article",
+        back_populates="generated_file_associations",
+        uselist=False,
+    )
+
+    file_id: Mapped[int] = mapped_column(
+        ForeignKey("generated_file.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    file: Mapped[GeneratedFile] = relationship(
+        "GeneratedFile",
         uselist=False,
     )

--- a/tests/sqlalchemy/sync/test_relation_group_map_with_proxy.py
+++ b/tests/sqlalchemy/sync/test_relation_group_map_with_proxy.py
@@ -1,0 +1,566 @@
+"""Test RelationGroupMap + association proxy integration with SQLAlchemy Materia.
+
+Part 1 – Alongside proxy:
+    Verifies that a transmuter with both a ``RelationGroupMap`` (backed by
+    ``attribute_keyed_list_dict``) and a scalar ``association_proxy`` field works
+    correctly.
+
+Part 2 – Proxy *over* attribute_keyed_list_dict:
+    Verifies that a ``RelationGroupMap`` mapped to an ``association_proxy``
+    that targets a ``attribute_keyed_list_dict``-backed relationship resolves
+    the proxy values correctly — the scenario where SQLAlchemy's
+    ``_AssociationDict`` cannot iterate dict-of-lists values on its own.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import Engine, select
+from sqlalchemy.orm import raiseload, selectinload
+
+from arcanus.association import RelationGroupMap
+from arcanus.materia.sqlalchemy import Session
+from tests.models import Article as ArticleModel
+from tests.models import ArticleGeneratedFile as ArticleGeneratedFileModel
+from tests.models import GeneratedFile as GeneratedFileModel
+from tests.models import Warehouse as WarehouseModel
+from tests.models import WarehouseItem as WarehouseItemModel
+from tests.models import WarehouseManager as WarehouseManagerModel
+from tests.transmuters import Article, Warehouse, WarehouseItem
+
+
+def _seed_warehouse(
+    session, *, name: str = "Main", manager_name: str | None = "Alice"
+) -> WarehouseModel:
+    """Insert a Warehouse with optional manager and sample items, flush & return."""
+    manager = None
+    if manager_name is not None:
+        manager = WarehouseManagerModel(name=manager_name)
+        session.add(manager)
+        session.flush()
+
+    wh = WarehouseModel(
+        name=name,
+        manager_id=manager.id if manager else None,
+    )
+    session.add(wh)
+    session.flush()
+
+    # Add some grouped items
+    items = [
+        WarehouseItemModel(
+            category="tools", name="Hammer", quantity=10, warehouse_id=wh.id
+        ),
+        WarehouseItemModel(
+            category="tools", name="Wrench", quantity=5, warehouse_id=wh.id
+        ),
+        WarehouseItemModel(
+            category="parts", name="Bolt", quantity=100, warehouse_id=wh.id
+        ),
+    ]
+    session.add_all(items)
+    session.flush()
+
+    return wh
+
+
+class TestRelationGroupMapWithProxyModelValidate:
+    """Test model_validate path with both grouped items and association proxy."""
+
+    def test_proxy_populated_when_manager_loaded(self, engine: Engine):
+        """manager_name proxy populated when manager relationship eagerly loaded."""
+        with Session(engine) as session:
+            orm_wh = _seed_warehouse(session, manager_name="Alice")
+            wh_id = orm_wh.id
+            session.commit()
+
+        with Session(engine) as session:
+            stmt = (
+                select(WarehouseModel)
+                .where(WarehouseModel.id == wh_id)
+                .options(selectinload(WarehouseModel.manager))
+            )
+            orm_wh = session.execute(stmt).scalar_one()
+
+            wh = Warehouse.model_validate(orm_wh)
+            assert wh.manager_name == "Alice"
+
+    def test_proxy_falls_back_when_manager_not_loaded(self, engine: Engine):
+        """manager_name falls back to None when manager relationship not loaded."""
+        with Session(engine) as session:
+            orm_wh = _seed_warehouse(session, manager_name="Bob")
+            wh_id = orm_wh.id
+            session.commit()
+
+        with Session(engine) as session:
+            stmt = select(WarehouseModel).where(WarehouseModel.id == wh_id)
+            orm_wh = session.execute(stmt).scalar_one()
+            # Expire to ensure not in inspector.dict
+            session.expire(orm_wh, ["manager"])
+
+            wh = Warehouse.model_validate(orm_wh)
+            assert wh.manager_name is None
+
+    def test_proxy_does_not_trigger_raiseload(self, engine: Engine):
+        """manager_name proxy must not trigger raiseload on manager."""
+        with Session(engine) as session:
+            orm_wh = _seed_warehouse(session, manager_name="Carol")
+            wh_id = orm_wh.id
+            session.commit()
+
+        with Session(engine) as session:
+            stmt = (
+                select(WarehouseModel)
+                .where(WarehouseModel.id == wh_id)
+                .options(raiseload(WarehouseModel.manager))
+            )
+            orm_wh = session.execute(stmt).scalar_one()
+
+            # Should NOT raise
+            wh = Warehouse.model_validate(orm_wh)
+            assert wh.manager_name is None
+
+    def test_grouped_items_load_alongside_proxy(self, engine: Engine):
+        """RelationGroupMap items load correctly when proxy is also present."""
+        with Session(engine) as session:
+            orm_wh = _seed_warehouse(session, manager_name="Diana")
+            wh_id = orm_wh.id
+            session.commit()
+
+        with Session(engine) as session:
+            stmt = (
+                select(WarehouseModel)
+                .where(WarehouseModel.id == wh_id)
+                .options(
+                    selectinload(WarehouseModel.manager),
+                    selectinload(WarehouseModel.items),
+                )
+            )
+            orm_wh = session.execute(stmt).scalar_one()
+
+            wh = Warehouse.model_validate(orm_wh)
+
+            # Proxy populated
+            assert wh.manager_name == "Diana"
+
+            # Grouped items populated
+            assert isinstance(wh.items, RelationGroupMap)
+            assert len(wh.items) == 2
+            assert len(wh.items["tools"]) == 2
+            assert len(wh.items["parts"]) == 1
+
+    def test_grouped_items_lazy_load_with_proxy(self, engine: Engine):
+        """Grouped items lazy-load after model_validate regardless of proxy state."""
+        with Session(engine) as session:
+            orm_wh = _seed_warehouse(session, manager_name="Eve")
+            wh_id = orm_wh.id
+            session.commit()
+
+        with Session(engine) as session:
+            stmt = (
+                select(WarehouseModel)
+                .where(WarehouseModel.id == wh_id)
+                .options(selectinload(WarehouseModel.manager))
+            )
+            orm_wh = session.execute(stmt).scalar_one()
+
+            wh = Warehouse.model_validate(orm_wh)
+            assert wh.manager_name == "Eve"
+
+            # Items not eagerly loaded — accessing triggers lazy load
+            assert len(wh.items) == 2
+            tool_names = {item.name for item in wh.items["tools"]}
+            assert tool_names == {"Hammer", "Wrench"}
+
+    def test_no_manager_with_grouped_items(self, engine: Engine):
+        """Warehouse without a manager still works with grouped items."""
+        with Session(engine) as session:
+            orm_wh = _seed_warehouse(session, manager_name=None)
+            wh_id = orm_wh.id
+            session.commit()
+
+        with Session(engine) as session:
+            stmt = (
+                select(WarehouseModel)
+                .where(WarehouseModel.id == wh_id)
+                .options(selectinload(WarehouseModel.items))
+            )
+            orm_wh = session.execute(stmt).scalar_one()
+
+            wh = Warehouse.model_validate(orm_wh)
+            assert wh.manager_name is None
+            assert len(wh.items) == 2
+
+
+class TestRelationGroupMapWithProxyCRUD:
+    """Test CRUD mutations on grouped items when association proxy is present."""
+
+    def test_create_with_proxy_and_grouped_items(self, engine: Engine):
+        """Create a warehouse with manager + grouped items through transmuters."""
+        with Session(engine) as session:
+            wh = Warehouse(name="New Warehouse")
+            session.add(wh)
+            session.flush()
+            wh.revalidate()
+
+            # Add items
+            wh.items["tools"] = [
+                WarehouseItem(category="tools", name="Drill", quantity=3),
+            ]
+            wh.items["parts"] = [
+                WarehouseItem(category="parts", name="Nut", quantity=50),
+            ]
+            session.flush()
+
+            assert len(wh.items) == 2
+            assert len(wh.items["tools"]) == 1
+            assert len(wh.items["parts"]) == 1
+
+    def test_append_items_with_proxy_present(self, engine: Engine):
+        """Append to grouped items while proxy field exists on the transmuter."""
+        with Session(engine) as session:
+            orm_wh = _seed_warehouse(session, manager_name="Frank")
+            wh_id = orm_wh.id
+            session.commit()
+
+        with Session(engine) as session:
+            stmt = (
+                select(WarehouseModel)
+                .where(WarehouseModel.id == wh_id)
+                .options(
+                    selectinload(WarehouseModel.manager),
+                    selectinload(WarehouseModel.items),
+                )
+            )
+            orm_wh = session.execute(stmt).scalar_one()
+            wh = Warehouse.model_validate(orm_wh)
+
+            assert wh.manager_name == "Frank"
+
+            # Append a new item
+            wh.items.append(
+                "tools",
+                WarehouseItem(category="tools", name="Level", quantity=1),
+            )
+            session.flush()
+
+            assert len(wh.items["tools"]) == 3
+            assert wh.manager_name == "Frank"
+
+    def test_discard_item_with_proxy_present(self, engine: Engine):
+        """Discard from grouped items while proxy field exists."""
+        with Session(engine) as session:
+            orm_wh = _seed_warehouse(session, manager_name="Grace")
+            wh_id = orm_wh.id
+            session.commit()
+
+        with Session(engine) as session:
+            stmt = (
+                select(WarehouseModel)
+                .where(WarehouseModel.id == wh_id)
+                .options(
+                    selectinload(WarehouseModel.manager),
+                    selectinload(WarehouseModel.items),
+                )
+            )
+            orm_wh = session.execute(stmt).scalar_one()
+            wh = Warehouse.model_validate(orm_wh)
+
+            assert wh.manager_name == "Grace"
+            assert len(wh.items["tools"]) == 2
+
+            # Remove one tool
+            tool_to_remove = wh.items["tools"][0]
+            wh.items.discard("tools", tool_to_remove)
+            session.flush()
+
+            assert len(wh.items["tools"]) == 1
+            assert wh.manager_name == "Grace"
+
+
+class TestRelationGroupMapWithProxySerialization:
+    """Test model_dump includes both grouped items and proxy values."""
+
+    def test_model_dump_includes_proxy_and_items(self, engine: Engine):
+        """model_dump contains both manager_name (proxy) and items (group map)."""
+        with Session(engine) as session:
+            orm_wh = _seed_warehouse(session, manager_name="Hank")
+            wh_id = orm_wh.id
+            session.commit()
+
+        with Session(engine) as session:
+            stmt = (
+                select(WarehouseModel)
+                .where(WarehouseModel.id == wh_id)
+                .options(
+                    selectinload(WarehouseModel.manager),
+                    selectinload(WarehouseModel.items),
+                )
+            )
+            orm_wh = session.execute(stmt).scalar_one()
+            wh = Warehouse.model_validate(orm_wh)
+
+            data = wh.model_dump()
+            assert data["manager_name"] == "Hank"
+            assert isinstance(data["items"], dict)
+            assert "tools" in data["items"]
+            assert "parts" in data["items"]
+            assert len(data["items"]["tools"]) == 2
+            assert len(data["items"]["parts"]) == 1
+
+    def test_model_dump_proxy_none_with_items(self, engine: Engine):
+        """model_dump has manager_name=None but items populated."""
+        with Session(engine) as session:
+            orm_wh = _seed_warehouse(session, manager_name=None)
+            wh_id = orm_wh.id
+            session.commit()
+
+        with Session(engine) as session:
+            stmt = (
+                select(WarehouseModel)
+                .where(WarehouseModel.id == wh_id)
+                .options(selectinload(WarehouseModel.items))
+            )
+            orm_wh = session.execute(stmt).scalar_one()
+            wh = Warehouse.model_validate(orm_wh)
+
+            data = wh.model_dump()
+            assert data["manager_name"] is None
+            assert len(data["items"]["tools"]) == 2
+
+
+class TestRelationGroupMapWithProxyModelConstruct:
+    """Test model_construct path with both grouped items and association proxy."""
+
+    def test_construct_with_proxy_and_items_loaded(self, engine: Engine):
+        """model_construct populates proxy + defers items when both loaded."""
+        with Session(engine) as session:
+            orm_wh = _seed_warehouse(session, manager_name="Ivy")
+            wh_id = orm_wh.id
+            session.commit()
+
+        with Session(engine) as session:
+            stmt = (
+                select(WarehouseModel)
+                .where(WarehouseModel.id == wh_id)
+                .options(
+                    selectinload(WarehouseModel.manager),
+                    selectinload(WarehouseModel.items),
+                )
+            )
+            orm_wh = session.execute(stmt).scalar_one()
+
+            wh = Warehouse.model_construct(data=orm_wh)
+            assert wh.manager_name == "Ivy"
+
+            # items should be accessible (lazy or eager)
+            assert isinstance(wh.items, RelationGroupMap)
+
+    def test_construct_proxy_skipped_when_not_loaded(self, engine: Engine):
+        """model_construct skips proxy when manager not loaded."""
+        with Session(engine) as session:
+            orm_wh = _seed_warehouse(session, manager_name="Jake")
+            wh_id = orm_wh.id
+            session.commit()
+
+        with Session(engine) as session:
+            stmt = select(WarehouseModel).where(WarehouseModel.id == wh_id)
+            orm_wh = session.execute(stmt).scalar_one()
+            session.expire(orm_wh, ["manager"])
+
+            wh = Warehouse.model_construct(data=orm_wh)
+            assert getattr(wh, "manager_name", None) is None
+
+
+class TestRelationGroupMapWithProxyPersistence:
+    """Test cross-session persistence with both features active."""
+
+    def test_items_persist_across_sessions_with_proxy(self, engine: Engine):
+        """Grouped items created in one session load correctly in another,
+        with association proxy also resolving correctly."""
+        with Session(engine) as session:
+            orm_wh = _seed_warehouse(session, manager_name="Karen")
+            wh_id = orm_wh.id
+            session.commit()
+
+        with Session(engine) as session:
+            stmt = (
+                select(WarehouseModel)
+                .where(WarehouseModel.id == wh_id)
+                .options(
+                    selectinload(WarehouseModel.manager),
+                    selectinload(WarehouseModel.items),
+                )
+            )
+            orm_wh = session.execute(stmt).scalar_one()
+            wh = Warehouse.model_validate(orm_wh)
+
+            assert wh.manager_name == "Karen"
+            assert set(wh.items.keys()) == {"tools", "parts"}
+            assert len(wh.items.flatten()) == 3
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Part 2 – RelationGroupMap mapped to an association_proxy over
+#           attribute_keyed_list_dict (proxy *over* the grouped relationship)
+# ═════════════════════════════════════════════════════════════════════════════
+
+
+def _seed_article(session, *, title: str = "Test Article") -> ArticleModel:
+    """Insert an Article with generated files grouped by role, flush & return."""
+    file1 = GeneratedFileModel(filename="cover.png", size=1024)
+    file2 = GeneratedFileModel(filename="banner.png", size=2048)
+    file3 = GeneratedFileModel(filename="data.csv", size=512)
+    session.add_all([file1, file2, file3])
+    session.flush()
+
+    article = ArticleModel(title=title)
+    session.add(article)
+    session.flush()
+
+    assocs = [
+        ArticleGeneratedFileModel(
+            role="image", article_id=article.id, file_id=file1.id
+        ),
+        ArticleGeneratedFileModel(
+            role="image", article_id=article.id, file_id=file2.id
+        ),
+        ArticleGeneratedFileModel(role="data", article_id=article.id, file_id=file3.id),
+    ]
+    session.add_all(assocs)
+    session.flush()
+
+    return article
+
+
+class TestProxyOverGroupedRelationshipLoading:
+    """Test that RelationGroupMap resolves association_proxy over
+    attribute_keyed_list_dict correctly during loading."""
+
+    def test_load_with_selectinload(self, engine: Engine):
+        """Eagerly loaded proxy-over-grouped-relationship populates RelationGroupMap."""
+        with Session(engine) as session:
+            orm_article = _seed_article(session)
+            article_id = orm_article.id
+            session.commit()
+
+        with Session(engine) as session:
+            stmt = (
+                select(ArticleModel)
+                .where(ArticleModel.id == article_id)
+                .options(
+                    selectinload(ArticleModel.generated_file_associations).selectinload(
+                        ArticleGeneratedFileModel.file
+                    )
+                )
+            )
+            orm_article = session.execute(stmt).scalar_one()
+
+            article = Article.model_validate(orm_article)
+            assert isinstance(article.generated_files, RelationGroupMap)
+            assert len(article.generated_files) == 2
+            assert len(article.generated_files["image"]) == 2
+            assert len(article.generated_files["data"]) == 1
+
+    def test_load_resolves_target_objects(self, engine: Engine):
+        """Values in the RelationGroupMap are the proxied target (GeneratedFile),
+        not the intermediate association (ArticleGeneratedFile)."""
+        with Session(engine) as session:
+            orm_article = _seed_article(session)
+            article_id = orm_article.id
+            session.commit()
+
+        with Session(engine) as session:
+            stmt = (
+                select(ArticleModel)
+                .where(ArticleModel.id == article_id)
+                .options(
+                    selectinload(ArticleModel.generated_file_associations).selectinload(
+                        ArticleGeneratedFileModel.file
+                    )
+                )
+            )
+            orm_article = session.execute(stmt).scalar_one()
+
+            article = Article.model_validate(orm_article)
+            filenames = {f.filename for f in article.generated_files["image"]}
+            assert filenames == {"cover.png", "banner.png"}
+            assert article.generated_files["data"][0].filename == "data.csv"
+
+    def test_lazy_load_proxy_over_grouped(self, engine: Engine):
+        """Lazy load works for proxy-over-grouped-relationship."""
+        with Session(engine) as session:
+            orm_article = _seed_article(session)
+            article_id = orm_article.id
+            session.commit()
+
+        with Session(engine) as session:
+            stmt = select(ArticleModel).where(ArticleModel.id == article_id)
+            orm_article = session.execute(stmt).scalar_one()
+
+            article = Article.model_validate(orm_article)
+            # Accessing should trigger lazy load
+            assert len(article.generated_files) == 2
+            assert len(article.generated_files["image"]) == 2
+
+
+class TestProxyOverGroupedRelationshipSerialization:
+    """Test model_dump with proxy-over-grouped-relationship."""
+
+    def test_model_dump_includes_resolved_files(self, engine: Engine):
+        """model_dump contains the resolved GeneratedFile data, not intermediates."""
+        with Session(engine) as session:
+            orm_article = _seed_article(session)
+            article_id = orm_article.id
+            session.commit()
+
+        with Session(engine) as session:
+            stmt = (
+                select(ArticleModel)
+                .where(ArticleModel.id == article_id)
+                .options(
+                    selectinload(ArticleModel.generated_file_associations).selectinload(
+                        ArticleGeneratedFileModel.file
+                    )
+                )
+            )
+            orm_article = session.execute(stmt).scalar_one()
+
+            article = Article.model_validate(orm_article)
+            data = article.model_dump()
+            assert isinstance(data["generated_files"], dict)
+            assert "image" in data["generated_files"]
+            assert "data" in data["generated_files"]
+            assert len(data["generated_files"]["image"]) == 2
+            assert len(data["generated_files"]["data"]) == 1
+            # Verify we get GeneratedFile fields, not ArticleGeneratedFile fields
+            img = data["generated_files"]["image"][0]
+            assert "filename" in img
+            assert "size" in img
+
+
+class TestProxyOverGroupedRelationshipPersistence:
+    """Test cross-session loading with proxy-over-grouped-relationship."""
+
+    def test_persist_and_reload(self, engine: Engine):
+        """Data created in one session loads correctly via proxy in another."""
+        with Session(engine) as session:
+            orm_article = _seed_article(session, title="Persistent Article")
+            article_id = orm_article.id
+            session.commit()
+
+        with Session(engine) as session:
+            stmt = (
+                select(ArticleModel)
+                .where(ArticleModel.id == article_id)
+                .options(
+                    selectinload(ArticleModel.generated_file_associations).selectinload(
+                        ArticleGeneratedFileModel.file
+                    )
+                )
+            )
+            orm_article = session.execute(stmt).scalar_one()
+
+            article = Article.model_validate(orm_article)
+            assert article.title == "Persistent Article"
+            assert set(article.generated_files.keys()) == {"image", "data"}
+            assert len(article.generated_files.flatten()) == 3

--- a/tests/transmuters.py
+++ b/tests/transmuters.py
@@ -507,6 +507,16 @@ class BlogPost(TestIdMixin, BaseTransmuter):
 
 
 # SQLAlchemy-blessed transmuters
+@sqlalchemy_materia.bless(models.WarehouseManager)
+class WarehouseManager(TestIdMixin, BaseTransmuter):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: Annotated[Optional[int], Identity] = Field(default=None, frozen=True)
+    name: str
+
+    warehouses: RelationCollection[Warehouse] = Relationships()
+
+
 @sqlalchemy_materia.bless(models.WarehouseItem)
 class WarehouseItem(TestIdMixin, BaseTransmuter):
     model_config = ConfigDict(from_attributes=True)
@@ -526,8 +536,48 @@ class Warehouse(TestIdMixin, BaseTransmuter):
 
     id: Annotated[Optional[int], Identity] = Field(default=None, frozen=True)
     name: str
+    manager_id: int | None = None
 
+    # Association proxy field
+    manager_name: str | None = None
+
+    # Normal associations
+    manager: Relation[WarehouseManager] = Relationship()
     items: RelationGroupMap[str, WarehouseItem] = GroupedRelationship()
+
+
+# ── Association proxy over attribute_keyed_list_dict transmuters ──
+
+
+@sqlalchemy_materia.bless(models.GeneratedFile)
+class GeneratedFile(TestIdMixin, BaseTransmuter):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: Annotated[Optional[int], Identity] = Field(default=None, frozen=True)
+    filename: str
+    size: int = 0
+
+
+@sqlalchemy_materia.bless(models.ArticleGeneratedFile)
+class ArticleGeneratedFile(TestIdMixin, BaseTransmuter):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: Annotated[Optional[int], Identity] = Field(default=None, frozen=True)
+    role: str
+    article_id: int | None = None
+    file_id: int | None = None
+
+    file: Relation[GeneratedFile] = Relationship()
+
+
+@sqlalchemy_materia.bless(models.Article)
+class Article(TestIdMixin, BaseTransmuter):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: Annotated[Optional[int], Identity] = Field(default=None, frozen=True)
+    title: str
+
+    generated_files: RelationGroupMap[str, GeneratedFile] = GroupedRelationship()
 
 
 # Unblessed transmuters for noop RelationGroupMap tests


### PR DESCRIPTION
## Problem

SQLAlchemy's `_AssociationDict` cannot iterate dict-of-lists values when an `association_proxy` targets a relationship using `attribute_keyed_list_dict`. The proxy applies its `value_attr` getter to each dict **value**, but with grouped collections the values are **lists**, causing:

```
AttributeError: 'list' object has no attribute 'file'
```

This breaks `RelationGroupMap._load()` which was iterating `self.__provided__.items()` — hitting the proxy's broken `__getitem__` on list values.

## Root Cause

Two issues combined:

1. **`RelationGroupMap._load()`** discarded the return value of `load_association()` and re-accessed `self.__provided__` (which goes through the proxy), unlike `_aload()` which correctly used the return value.

2. **`SqlalchemyMateria.load_association()`** returned the proxy object directly, but SQLAlchemy's `_AssociationDict` wrapping a `KeyFuncListDict` (dict-of-lists) cannot iterate correctly — it tries `list.file` instead of `item.file` for each item in the list.

## Fix

### `arcanus/association.py`
- `RelationGroupMap._load()` now uses the return value from `load_association()` (consistent with `_aload()`)
- Added `__backing_attr__` — when the materia detects a proxy, it sets this so that mutation operations (`append`, `discard`, `clear`, etc.) route through the underlying collection class instead of the proxy

### `arcanus/materia/sqlalchemy/base.py`
- `load_association()` detects when a `RelationGroupMap` field maps to an `association_proxy`
- Bypasses the proxy, loads the underlying relationship directly, and manually resolves the proxy's `value_attr` for each element in each list
- Returns a plain `dict[K, list[target_ORM]]` that the association can consume directly

## Test Coverage

### New models & transmuters
- `Article`, `GeneratedFile`, `ArticleGeneratedFile` — reproduces the exact production pattern (proxy with `creator` over `attribute_keyed_list_dict`)
- `WarehouseManager` + `Warehouse.manager_name` proxy — tests `RelationGroupMap` alongside a scalar proxy

### 19 new tests across 8 test classes

| Class | Tests |
|---|---|
| `TestRelationGroupMapWithProxyModelValidate` | proxy populated when loaded, fallback when not loaded, raiseload safety, grouped items + proxy together, lazy load with proxy, no manager with items |
| `TestRelationGroupMapWithProxyCRUD` | create with both features, append items with proxy, discard items with proxy |
| `TestRelationGroupMapWithProxySerialization` | `model_dump` with both, `model_dump` with proxy=None |
| `TestRelationGroupMapWithProxyModelConstruct` | construct with both loaded, construct with proxy skipped |
| `TestRelationGroupMapWithProxyPersistence` | cross-session persistence |
| `TestProxyOverGroupedRelationshipLoading` | selectinload, target object resolution, lazy load |
| `TestProxyOverGroupedRelationshipSerialization` | `model_dump` contains resolved target fields |
| `TestProxyOverGroupedRelationshipPersistence` | cross-session reload |

All 789 tests pass (789 passed, 1 skipped).