### PR TITLE
create second materia for redis

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,7 @@ jobs:
         run: uv python install 3.11
 
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --dev --all-extras
 
       - name: Run unit tests with coverage
         run: uv run pytest tests/ -v --tb=short --cov=arcanus --cov-report=xml --cov-report=term
@@ -103,7 +103,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --dev --all-extras
 
       - name: Run benchmarks (${{ matrix.mode }} mode)
         uses: CodSpeedHQ/action@v4

--- a/arcanus/materia/redis/__init__.py
+++ b/arcanus/materia/redis/__init__.py
@@ -1,0 +1,15 @@
+try:
+    import redis as _redis  # noqa: F401
+except ImportError as e:
+    raise ImportError(
+        "Install arcanus[redis] to use RedisMateria: pip install arcanus[redis]"
+    ) from e
+
+from arcanus.materia.redis.base import RedisMateria
+from arcanus.materia.redis.client import AsyncClient, Client
+
+__all__ = [
+    "RedisMateria",
+    "Client",
+    "AsyncClient",
+]

--- a/arcanus/materia/redis/base.py
+++ b/arcanus/materia/redis/base.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypeVar
+
+from arcanus.materia.base import BaseMateria
+
+if TYPE_CHECKING:
+    from arcanus.association import Association
+    from arcanus.base import Transmuter
+
+T = TypeVar("T", bound="Transmuter")
+
+
+class RedisMateria(BaseMateria):
+    key_prefixes: dict[type[Transmuter], str]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.key_prefixes = {}
+
+    def bless(self, key_prefix: str | None = None):
+        """Register *transmuter_cls* with an optional Redis key prefix.
+
+        If ``key_prefix`` is omitted, the transmuter's class name is used.
+        Redis keys are formatted as ``{prefix}:{identity}``.
+        """
+
+        def decorator(transmuter_cls: type[T]) -> type[T]:
+            prefix = key_prefix if key_prefix is not None else transmuter_cls.__name__
+            self.key_prefixes[transmuter_cls] = prefix
+            return transmuter_cls
+
+        return decorator
+
+    def load_association(self, association: Association) -> None:
+        return
+
+    async def aload_association(self, association: Association) -> None:
+        return

--- a/arcanus/materia/redis/client.py
+++ b/arcanus/materia/redis/client.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from typing import (
+    TYPE_CHECKING,
+    Optional,
+    TypeVar,
+    Union,
+    cast,
+)
+
+from uuid import UUID
+
+import redis
+import redis.asyncio
+
+from arcanus.base import Transmuter, TransmuterMetaclass
+from arcanus.materia.base import active_materia
+from arcanus.materia.redis.base import RedisMateria
+from arcanus.utils import get_cached_adapter
+
+if TYPE_CHECKING:
+    from redis.typing import AbsExpiryT, ExpiryT
+
+T = TypeVar("T", bound=Transmuter)
+
+ScalarIdentT = Union[str, int, UUID]
+IdentT = Union[ScalarIdentT, tuple[ScalarIdentT, ...]]
+
+
+def _make_key(entity: type[Transmuter], ident: IdentT) -> str:
+    materia = active_materia.get()
+    if not isinstance(materia, RedisMateria):
+        raise RuntimeError(
+            "No active RedisMateria found. Activate one with 'with redis_materia:' "
+            "before calling transmuter-aware client helpers."
+        )
+    suffix = ":".join(str(x) for x in ident) if isinstance(ident, tuple) else str(ident)
+    return f"{materia.key_prefixes[entity]}:{suffix}"
+
+
+def _instance_key(instance: Transmuter) -> str:
+    meta = cast(TransmuterMetaclass, type(instance))
+    identities = meta.__transmuter_identities__
+    if not identities:
+        raise ValueError(
+            f"Transmuter {type(instance).__name__} has no Identity fields; "
+            "cannot derive a Redis key automatically."
+        )
+    ident = tuple(getattr(instance, field) for field in identities)
+    return _make_key(type(instance), ident)
+
+
+class Client(redis.Redis):
+    """Subclass of :class:`redis.Redis` that adds transmuter-aware helpers.
+
+    The native ``get``/``set``/``delete``/``mget`` methods are untouched and
+    continue to behave exactly like the parent class. The ``t*`` helpers below
+    operate on :class:`Transmuter` instances and store/retrieve them as JSON.
+
+    The active :class:`RedisMateria` is read from the context var, so the caller
+    is responsible for activating it (``with redis_materia:``) before invoking
+    any ``t*`` helper.
+    """
+
+    def tget(self, entity: type[T], ident: IdentT) -> Optional[T]:
+        key = _make_key(entity, ident)
+        data = cast(Optional[bytes], self.get(key))
+        if data is None:
+            return None
+        return get_cached_adapter(entity).validate_json(data)
+
+    def tset(
+        self,
+        instance: Transmuter,
+        ex: Union[ExpiryT, None] = None,
+        px: Union[ExpiryT, None] = None,
+        nx: bool = False,
+        xx: bool = False,
+        keepttl: bool = False,
+        exat: Union[AbsExpiryT, None] = None,
+        pxat: Union[AbsExpiryT, None] = None,
+    ) -> Optional[bool]:
+        key = _instance_key(instance)
+        payload = get_cached_adapter(type(instance)).dump_json(instance)
+        return cast(
+            Optional[bool],
+            self.set(
+                key,
+                payload,
+                ex=ex,
+                px=px,
+                nx=nx,
+                xx=xx,
+                keepttl=keepttl,
+                exat=exat,
+                pxat=pxat,
+            ),
+        )
+
+    def tdelete(self, entity: type[Transmuter], *idents: IdentT) -> int:
+        if not idents:
+            return 0
+        keys = [_make_key(entity, i) for i in idents]
+        return cast(int, self.delete(*keys))
+
+    def tmget(self, entity: type[T], *idents: IdentT) -> list[Optional[T]]:
+        if not idents:
+            return []
+        keys = [_make_key(entity, i) for i in idents]
+        raw = cast(list[Optional[bytes]], self.mget(keys))
+        adapter = get_cached_adapter(entity)
+        return [adapter.validate_json(v) if v is not None else None for v in raw]
+
+
+class AsyncClient(redis.asyncio.Redis):
+    """Async counterpart of :class:`Client`. See :class:`Client` for details."""
+
+    async def tget(self, entity: type[T], ident: IdentT) -> Optional[T]:
+        key = _make_key(entity, ident)
+        data: Optional[bytes] = await self.get(key)
+        if data is None:
+            return None
+        return get_cached_adapter(entity).validate_json(data)
+
+    async def tset(
+        self,
+        instance: Transmuter,
+        ex: Union[ExpiryT, None] = None,
+        px: Union[ExpiryT, None] = None,
+        nx: bool = False,
+        xx: bool = False,
+        keepttl: bool = False,
+        exat: Union[AbsExpiryT, None] = None,
+        pxat: Union[AbsExpiryT, None] = None,
+    ) -> Optional[bool]:
+        key = _instance_key(instance)
+        payload = get_cached_adapter(type(instance)).dump_json(instance)
+        result: Optional[bool] = await self.set(
+            key,
+            payload,
+            ex=ex,
+            px=px,
+            nx=nx,
+            xx=xx,
+            keepttl=keepttl,
+            exat=exat,
+            pxat=pxat,
+        )
+        return result
+
+    async def tdelete(self, entity: type[Transmuter], *idents: IdentT) -> int:
+        if not idents:
+            return 0
+        keys = [_make_key(entity, i) for i in idents]
+        result: int = await self.delete(*keys)
+        return result
+
+    async def tmget(self, entity: type[T], *idents: IdentT) -> list[Optional[T]]:
+        if not idents:
+            return []
+        keys = [_make_key(entity, i) for i in idents]
+        raw = await self.mget(keys)
+        adapter = get_cached_adapter(entity)
+        return [adapter.validate_json(v) if v is not None else None for v in raw]

--- a/arcanus/materia/sqlalchemy/__init__.py
+++ b/arcanus/materia/sqlalchemy/__init__.py
@@ -1,3 +1,11 @@
+try:
+    import sqlalchemy as _sqlalchemy  # noqa: F401
+except ImportError as e:
+    raise ImportError(
+        "Install arcanus[sqlalchemy] to use SqlalchemyMateria: "
+        "pip install arcanus[sqlalchemy]"
+    ) from e
+
 from arcanus.materia.sqlalchemy.base import SqlalchemyMateria
 from arcanus.materia.sqlalchemy.collections import attribute_keyed_list_dict
 from arcanus.materia.sqlalchemy.database import AsyncSession, Session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,7 @@ classifiers = [
 ]
 keywords = ["pydantic", "database", "schema", "orm", "datasource", "sqlmodel", "sqlalchemy"]
 dependencies = [
-    "sqlalchemy>=2.0.0",
     "pydantic>=2.11.7",
-    "greenlet>=3.2.4",
 ]
 
 [project.optional-dependencies]
@@ -37,6 +35,10 @@ dev = [
     "mypy>=1.0.0",
     "pre-commit>=3.0.0",
     "asyncpg>=0.28.0",
+]
+sqlalchemy = [
+    "sqlalchemy>=2.0.0",
+    "greenlet>=3.2.4",
 ]
 redis = [
     "redis>=5.0.0",
@@ -54,13 +56,14 @@ dev = [
     "pytest-cov>=4.1.0",
     "pytest-codspeed>=4.2.0",
     "pytest-xdist>=3.5.0",
+    "pytest-benchmark>=5.2.3",
     "mypy>=1.0.0",
     "pre-commit>=3.0.0",
+    # SQL drivers needed only for SqlalchemyMateria tests
     "aiosqlite>=0.19.0",
-    "pytest-benchmark>=5.2.3",
     "psycopg2-binary>=2.9.11",
     "asyncpg>=0.30.0",
-    "redis>=5.0.0",
+    # Redis test double — not a runtime dep
     "fakeredis>=2.0.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ dev = [
     "pre-commit>=3.0.0",
     "asyncpg>=0.28.0",
 ]
+redis = [
+    "redis>=5.0.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/kalynnka/arcanus"
@@ -57,6 +60,8 @@ dev = [
     "pytest-benchmark>=5.2.3",
     "psycopg2-binary>=2.9.11",
     "asyncpg>=0.30.0",
+    "redis>=5.0.0",
+    "fakeredis>=2.0.0",
 ]
 
 [tool.ruff]

--- a/tests/redis/conftest.py
+++ b/tests/redis/conftest.py
@@ -1,0 +1,95 @@
+"""Fixtures and shared transmuters for Redis materia tests."""
+
+from __future__ import annotations
+
+from typing import Annotated, Optional
+from uuid import UUID
+
+import fakeredis
+import fakeredis.aioredis
+import pytest
+from pydantic import ConfigDict, Field
+
+from arcanus.association import (
+    Relation,
+    RelationCollection,
+    Relationship,
+    Relationships,
+)
+from arcanus.base import BaseTransmuter, Identity
+from arcanus.materia.redis import AsyncClient, Client, RedisMateria
+
+redis_materia = RedisMateria()
+
+
+@redis_materia.bless()
+class Author(BaseTransmuter):
+    model_config = ConfigDict(from_attributes=True)
+    id: Annotated[Optional[int], Identity] = Field(default=None, frozen=True)
+    name: str
+    books: RelationCollection["Book"] = Relationships()
+
+
+@redis_materia.bless()
+class Book(BaseTransmuter):
+    model_config = ConfigDict(from_attributes=True)
+    id: Annotated[Optional[int], Identity] = Field(default=None, frozen=True)
+    title: str
+    author: Relation[Optional[Author]] = Relationship()
+
+
+@redis_materia.bless(key_prefix="users")
+class User(BaseTransmuter):
+    model_config = ConfigDict(from_attributes=True)
+    id: Annotated[UUID, Identity] = Field(frozen=True)
+    name: str
+
+
+@redis_materia.bless()
+class BookCategory(BaseTransmuter):
+    """Composite identity (book_id, category_id)."""
+
+    model_config = ConfigDict(from_attributes=True)
+    book_id: Annotated[int, Identity] = Field(frozen=True)
+    category_id: Annotated[int, Identity] = Field(frozen=True)
+
+
+class Unblessed(BaseTransmuter):
+    """Has Identity but isn't blessed — used to test the unblessed-key error."""
+
+    model_config = ConfigDict(from_attributes=True)
+    id: Annotated[Optional[int], Identity] = Field(default=None, frozen=True)
+    name: str
+
+
+@redis_materia.bless()
+class NoIdentity(BaseTransmuter):
+    """Blessed but has no Identity fields — used to test the missing-identity error."""
+
+    model_config = ConfigDict(from_attributes=True)
+    name: str
+
+
+class FakeClient(Client, fakeredis.FakeRedis):
+    """Sync Client backed by an in-memory fakeredis server."""
+
+
+class FakeAsyncClient(AsyncClient, fakeredis.aioredis.FakeRedis):
+    """Async Client backed by an in-memory fakeredis server."""
+
+
+@pytest.fixture
+def client() -> FakeClient:
+    return FakeClient()
+
+
+@pytest.fixture
+async def async_client() -> FakeAsyncClient:
+    return FakeAsyncClient()
+
+
+@pytest.fixture
+def materia_active():
+    """Enter the RedisMateria context for the duration of the test."""
+    with redis_materia:
+        yield redis_materia

--- a/tests/redis/test_async_client.py
+++ b/tests/redis/test_async_client.py
@@ -1,0 +1,141 @@
+"""Tests for the async Redis :class:`AsyncClient` (mirrors test_client.py)."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from arcanus.association import Relation
+from tests.redis.conftest import (
+    Author,
+    Book,
+    BookCategory,
+    FakeAsyncClient,
+    NoIdentity,
+    Unblessed,
+    User,
+)
+
+
+class TestKeyFormat:
+    async def test_default_prefix_is_class_name(
+        self, async_client: FakeAsyncClient, materia_active
+    ):
+        await async_client.tset(Author(id=1, name="Asimov"))
+        assert await async_client.get("Author:1") is not None
+
+    async def test_custom_prefix(self, async_client: FakeAsyncClient, materia_active):
+        uid = uuid4()
+        await async_client.tset(User(id=uid, name="alice"))
+        assert await async_client.get(f"users:{uid}") is not None
+
+    async def test_uuid_ident(self, async_client: FakeAsyncClient, materia_active):
+        uid = uuid4()
+        await async_client.tset(User(id=uid, name="alice"))
+        got = await async_client.tget(User, uid)
+        assert got is not None and got.name == "alice"
+
+    async def test_composite_tuple_ident(
+        self, async_client: FakeAsyncClient, materia_active
+    ):
+        await async_client.tset(BookCategory(book_id=10, category_id=20))
+        got = await async_client.tget(BookCategory, (10, 20))
+        assert got is not None and got.book_id == 10
+
+
+class TestCRUD:
+    async def test_set_get_roundtrip(
+        self, async_client: FakeAsyncClient, materia_active
+    ):
+        await async_client.tset(Author(id=1, name="Asimov"))
+        loaded = await async_client.tget(Author, 1)
+        assert loaded is not None and loaded.name == "Asimov"
+        assert isinstance(loaded, Author)
+
+    async def test_get_missing_returns_none(
+        self, async_client: FakeAsyncClient, materia_active
+    ):
+        assert await async_client.tget(Author, 999) is None
+
+    async def test_delete_existing(self, async_client: FakeAsyncClient, materia_active):
+        await async_client.tset(Author(id=1, name="x"))
+        assert await async_client.tdelete(Author, 1) == 1
+        assert await async_client.tget(Author, 1) is None
+
+    async def test_delete_variadic(self, async_client: FakeAsyncClient, materia_active):
+        for i in (1, 2, 3):
+            await async_client.tset(Author(id=i, name=f"a{i}"))
+        assert await async_client.tdelete(Author, 1, 2, 3) == 3
+
+    async def test_delete_empty_returns_zero(
+        self, async_client: FakeAsyncClient, materia_active
+    ):
+        assert await async_client.tdelete(Author) == 0
+
+    async def test_mget_mixed_hits_and_misses(
+        self, async_client: FakeAsyncClient, materia_active
+    ):
+        await async_client.tset(Author(id=1, name="a"))
+        await async_client.tset(Author(id=3, name="c"))
+        results = await async_client.tmget(Author, 1, 2, 3)
+        assert results[0] is not None and results[0].name == "a"
+        assert results[1] is None
+        assert results[2] is not None and results[2].name == "c"
+
+    async def test_mget_empty_returns_empty(
+        self, async_client: FakeAsyncClient, materia_active
+    ):
+        assert await async_client.tmget(Author) == []
+
+
+class TestNativeRedisPassthrough:
+    async def test_native_set_get(self, async_client: FakeAsyncClient):
+        await async_client.set("raw-key", "raw-value")
+        assert await async_client.get("raw-key") == b"raw-value"
+
+    async def test_native_delete(self, async_client: FakeAsyncClient):
+        await async_client.set("k1", "v1")
+        await async_client.set("k2", "v2")
+        assert await async_client.delete("k1", "k2") == 2
+
+
+class TestSerialization:
+    async def test_nested_relation_roundtrip(
+        self, async_client: FakeAsyncClient, materia_active
+    ):
+        author = Author(id=1, name="Asimov")
+        book = Book(id=42, title="Foundation", author=Relation(author))
+        await async_client.tset(book)
+
+        loaded = await async_client.tget(Book, 42)
+        assert loaded is not None
+        assert loaded.author.value is not None
+        assert loaded.author.value.name == "Asimov"
+
+
+class TestErrors:
+    async def test_missing_materia_raises(self, async_client: FakeAsyncClient):
+        with pytest.raises(RuntimeError, match="RedisMateria"):
+            await async_client.tget(Author, 1)
+
+    async def test_unblessed_transmuter_raises_key_error(
+        self, async_client: FakeAsyncClient, materia_active
+    ):
+        with pytest.raises(KeyError):
+            await async_client.tset(Unblessed(id=1, name="x"))
+
+    async def test_no_identity_fields_raises_value_error(
+        self, async_client: FakeAsyncClient, materia_active
+    ):
+        with pytest.raises(ValueError, match="no Identity fields"):
+            await async_client.tset(NoIdentity(name="x"))
+
+
+class TestTTL:
+    async def test_set_with_ex_seconds(
+        self, async_client: FakeAsyncClient, materia_active
+    ):
+        await async_client.tset(Author(id=1, name="x"), ex=60)
+        ttl = await async_client.ttl("Author:1")
+        assert 0 < ttl <= 60

--- a/tests/redis/test_client.py
+++ b/tests/redis/test_client.py
@@ -1,0 +1,248 @@
+"""Tests for the sync Redis :class:`Client`."""
+
+from __future__ import annotations
+
+from typing import cast
+from uuid import uuid4
+
+import pytest
+
+from arcanus.association import Association, Relation
+from arcanus.base import BaseTransmuter
+from arcanus.materia.redis import RedisMateria
+from tests.redis.conftest import (
+    Author,
+    Book,
+    BookCategory,
+    FakeClient,
+    NoIdentity,
+    Unblessed,
+    User,
+    redis_materia,
+)
+
+
+class TestKeyFormat:
+    def test_default_prefix_is_class_name(self, client: FakeClient, materia_active):
+        client.tset(Author(id=1, name="Asimov"))
+        assert client.get("Author:1") is not None
+
+    def test_custom_prefix(self, client: FakeClient, materia_active):
+        uid = uuid4()
+        client.tset(User(id=uid, name="alice"))
+        assert client.get(f"users:{uid}") is not None
+
+    def test_int_ident(self, client: FakeClient, materia_active):
+        client.tset(Author(id=42, name="x"))
+        assert client.tget(Author, 42) is not None
+
+    def test_str_ident_lookup(self, client: FakeClient, materia_active):
+        # str(int) and int produce the same key suffix
+        client.tset(Author(id=42, name="x"))
+        assert client.tget(Author, "42") is not None
+
+    def test_uuid_ident(self, client: FakeClient, materia_active):
+        uid = uuid4()
+        client.tset(User(id=uid, name="alice"))
+        got = client.tget(User, uid)
+        assert got is not None and got.name == "alice"
+
+    def test_composite_tuple_ident(self, client: FakeClient, materia_active):
+        client.tset(BookCategory(book_id=10, category_id=20))
+        assert client.get("BookCategory:10:20") is not None
+        got = client.tget(BookCategory, (10, 20))
+        assert got is not None and got.book_id == 10 and got.category_id == 20
+
+
+class TestCRUD:
+    def test_set_get_roundtrip(self, client: FakeClient, materia_active):
+        a = Author(id=1, name="Asimov")
+        client.tset(a)
+        loaded = client.tget(Author, 1)
+        assert loaded is not None
+        assert isinstance(loaded, Author)
+        assert loaded.id == 1
+        assert loaded.name == "Asimov"
+
+    def test_get_missing_returns_none(self, client: FakeClient, materia_active):
+        assert client.tget(Author, 999) is None
+
+    def test_delete_existing(self, client: FakeClient, materia_active):
+        client.tset(Author(id=1, name="x"))
+        assert client.tdelete(Author, 1) == 1
+        assert client.tget(Author, 1) is None
+
+    def test_delete_missing(self, client: FakeClient, materia_active):
+        assert client.tdelete(Author, 999) == 0
+
+    def test_delete_variadic(self, client: FakeClient, materia_active):
+        client.tset(Author(id=1, name="a"))
+        client.tset(Author(id=2, name="b"))
+        client.tset(Author(id=3, name="c"))
+        assert client.tdelete(Author, 1, 2, 3) == 3
+        assert client.tget(Author, 1) is None
+        assert client.tget(Author, 2) is None
+        assert client.tget(Author, 3) is None
+
+    def test_delete_empty_returns_zero(self, client: FakeClient, materia_active):
+        assert client.tdelete(Author) == 0
+
+    def test_mget_all_hits(self, client: FakeClient, materia_active):
+        client.tset(Author(id=1, name="a"))
+        client.tset(Author(id=2, name="b"))
+        results = client.tmget(Author, 1, 2)
+        assert len(results) == 2
+        assert results[0] is not None and results[0].name == "a"
+        assert results[1] is not None and results[1].name == "b"
+
+    def test_mget_mixed_hits_and_misses(
+        self, client: FakeClient, materia_active
+    ):
+        client.tset(Author(id=1, name="a"))
+        client.tset(Author(id=3, name="c"))
+        results = client.tmget(Author, 1, 2, 3)
+        assert results[0] is not None and results[0].name == "a"
+        assert results[1] is None
+        assert results[2] is not None and results[2].name == "c"
+
+    def test_mget_all_misses(self, client: FakeClient, materia_active):
+        assert client.tmget(Author, 100, 200, 300) == [None, None, None]
+
+    def test_mget_empty_returns_empty(self, client: FakeClient, materia_active):
+        assert client.tmget(Author) == []
+
+    def test_mget_preserves_order(self, client: FakeClient, materia_active):
+        for i in range(5):
+            client.tset(Author(id=i, name=f"a{i}"))
+        results = client.tmget(Author, 4, 0, 2, 1, 3)
+        assert [r.name for r in results if r is not None] == ["a4", "a0", "a2", "a1", "a3"]
+
+
+class TestNativeRedisPassthrough:
+    """The native get/set/delete/mget must keep working unchanged."""
+
+    def test_native_set_get(self, client: FakeClient):
+        client.set("raw-key", "raw-value")
+        assert client.get("raw-key") == b"raw-value"
+
+    def test_native_delete(self, client: FakeClient):
+        client.set("k1", "v1")
+        client.set("k2", "v2")
+        assert client.delete("k1", "k2") == 2
+
+    def test_native_mget(self, client: FakeClient):
+        client.set("k1", "v1")
+        client.set("k2", "v2")
+        assert client.mget(["k1", "missing", "k2"]) == [b"v1", None, b"v2"]
+
+
+class TestSerialization:
+    def test_nested_relation_roundtrip(self, client: FakeClient, materia_active):
+        # Loaded association: explicit value triggers serialization
+        author = Author(id=1, name="Asimov")
+        book = Book(id=42, title="Foundation", author=Relation(author))
+        client.tset(book)
+
+        loaded = client.tget(Book, 42)
+        assert loaded is not None
+        assert loaded.title == "Foundation"
+        assert loaded.author.value is not None
+        assert loaded.author.value.name == "Asimov"
+
+    def test_unloaded_associations_excluded_from_dump(
+        self, client: FakeClient, materia_active
+    ):
+        # Author with no .books set → unloaded → not in JSON → tget rehydrates
+        # and accessing .books triggers load_association which is a noop
+        client.tset(Author(id=1, name="a"))
+        loaded = client.tget(Author, 1)
+        assert loaded is not None
+        assert loaded.name == "a"
+        # books is unloaded; the noop materia returns None which validates to []
+        assert list(loaded.books) == []
+
+
+class TestErrors:
+    def test_missing_materia_raises(self, client: FakeClient):
+        # NOT using the materia_active fixture
+        with pytest.raises(RuntimeError, match="RedisMateria"):
+            client.tget(Author, 1)
+
+    def test_unblessed_transmuter_raises_key_error(
+        self, client: FakeClient, materia_active
+    ):
+        with pytest.raises(KeyError):
+            client.tset(Unblessed(id=1, name="x"))
+
+    def test_no_identity_fields_raises_value_error(
+        self, client: FakeClient, materia_active
+    ):
+        with pytest.raises(ValueError, match="no Identity fields"):
+            client.tset(NoIdentity(name="x"))
+
+
+class TestTTL:
+    def test_set_with_ex_seconds(self, client: FakeClient, materia_active):
+        client.tset(Author(id=1, name="x"), ex=60)
+        ttl = cast(int, client.ttl("Author:1"))
+        assert 0 < ttl <= 60
+
+    def test_set_without_ex_has_no_ttl(self, client: FakeClient, materia_active):
+        client.tset(Author(id=1, name="x"))
+        # -1 = key exists with no expiry
+        assert cast(int, client.ttl("Author:1")) == -1
+
+
+class TestRedisMateria:
+    def test_load_association_is_noop(self):
+        m = RedisMateria()
+        # association arg is unused by the noop, just need a placeholder
+        assert m.load_association(cast(Association, None)) is None
+
+    def test_bless_returns_decorated_class(self):
+        m = RedisMateria()
+
+        @m.bless()
+        class T(BaseTransmuter):
+            pass
+
+        assert m.key_prefixes[T] == "T"
+
+    def test_bless_with_custom_prefix(self):
+        m = RedisMateria()
+
+        @m.bless(key_prefix="custom")
+        class T(BaseTransmuter):
+            pass
+
+        assert m.key_prefixes[T] == "custom"
+
+    def test_bless_positional_prefix(self):
+        m = RedisMateria()
+
+        @m.bless("positional")
+        class T(BaseTransmuter):
+            pass
+
+        assert m.key_prefixes[T] == "positional"
+
+
+class TestMateriaContext:
+    def test_aload_association_is_noop(self):
+        import asyncio
+
+        m = RedisMateria()
+        # placeholder association; noop ignores it
+        assert asyncio.run(m.aload_association(cast(Association, None))) is None
+
+    def test_nested_materia_context(self, client: FakeClient):
+        # Verify nested `with redis_materia:` works (shallow copy each time)
+        with redis_materia:
+            client.tset(Author(id=1, name="outer"))
+            with redis_materia():  # nested
+                client.tset(Author(id=2, name="inner"))
+            # Both writes hit the same fake server
+            outer = client.tget(Author, 1)
+            inner = client.tget(Author, 2)
+            assert outer is not None and outer.name == "outer"
+            assert inner is not None and inner.name == "inner"

--- a/tests/redis/test_client.py
+++ b/tests/redis/test_client.py
@@ -95,9 +95,7 @@ class TestCRUD:
         assert results[0] is not None and results[0].name == "a"
         assert results[1] is not None and results[1].name == "b"
 
-    def test_mget_mixed_hits_and_misses(
-        self, client: FakeClient, materia_active
-    ):
+    def test_mget_mixed_hits_and_misses(self, client: FakeClient, materia_active):
         client.tset(Author(id=1, name="a"))
         client.tset(Author(id=3, name="c"))
         results = client.tmget(Author, 1, 2, 3)
@@ -115,7 +113,13 @@ class TestCRUD:
         for i in range(5):
             client.tset(Author(id=i, name=f"a{i}"))
         results = client.tmget(Author, 4, 0, 2, 1, 3)
-        assert [r.name for r in results if r is not None] == ["a4", "a0", "a2", "a1", "a3"]
+        assert [r.name for r in results if r is not None] == [
+            "a4",
+            "a0",
+            "a2",
+            "a1",
+            "a3",
+        ]
 
 
 class TestNativeRedisPassthrough:

--- a/tests/redis/test_materia_switching.py
+++ b/tests/redis/test_materia_switching.py
@@ -301,9 +301,7 @@ class TestMultipleRedisMateriaInstances:
         # And the registries are physically separate dicts.
         assert m1.key_prefixes is not m2.key_prefixes
 
-    def test_swapping_between_two_redis_materias(
-        self, fake_client: FakeClient
-    ):
+    def test_swapping_between_two_redis_materias(self, fake_client: FakeClient):
         """The active RedisMateria determines which key prefix Client uses."""
         m1 = RedisMateria()
         m2 = RedisMateria()

--- a/tests/redis/test_materia_switching.py
+++ b/tests/redis/test_materia_switching.py
@@ -1,0 +1,420 @@
+"""Tests covering interaction between :class:`RedisMateria` and
+:class:`SqlalchemyMateria` — context switching and cache-aside patterns.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Optional
+
+import fakeredis
+import pytest
+from pydantic import ConfigDict, Field
+from sqlalchemy import Engine, Integer, String, create_engine, delete, select
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+from arcanus.base import BaseTransmuter, Identity, TransmuterProxiedMixin, validated
+from arcanus.materia.base import NoOpMateria, active_materia
+from arcanus.materia.redis import Client, RedisMateria
+from arcanus.materia.sqlalchemy import Session, SqlalchemyMateria
+
+
+class _Base(DeclarativeBase, TransmuterProxiedMixin):
+    pass
+
+
+class CityORM(_Base):
+    __tablename__ = "redis_switching_city"
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+
+
+sqlalchemy_materia = SqlalchemyMateria()
+redis_materia = RedisMateria()
+
+
+@redis_materia.bless()
+@sqlalchemy_materia.bless(CityORM)
+class City(BaseTransmuter):
+    model_config = ConfigDict(from_attributes=True)
+    id: Annotated[Optional[int], Identity] = Field(default=None, frozen=True)
+    name: str
+
+
+class FakeClient(Client, fakeredis.FakeRedis):
+    """Sync Client backed by an in-memory fakeredis server."""
+
+
+@pytest.fixture(scope="module")
+def engine() -> Engine:
+    eng = create_engine("sqlite:///:memory:")
+    _Base.metadata.create_all(eng)
+    return eng
+
+
+@pytest.fixture
+def fake_client() -> FakeClient:
+    return FakeClient()
+
+
+class TestActiveMateriaSwapping:
+    def test_nested_contexts_restore_correctly(self):
+        """Nested with-statements: inner replaces, exit restores outer."""
+        outer = active_materia.get()
+
+        with redis_materia:
+            assert active_materia.get() is redis_materia
+            with sqlalchemy_materia:
+                assert active_materia.get() is sqlalchemy_materia
+            assert active_materia.get() is redis_materia
+
+        assert active_materia.get() is outer
+
+    def test_reverse_nesting(self):
+        """Order doesn't matter — sql first, then redis inside."""
+        with sqlalchemy_materia:
+            assert active_materia.get() is sqlalchemy_materia
+            with redis_materia:
+                assert active_materia.get() is redis_materia
+            assert active_materia.get() is sqlalchemy_materia
+
+    def test_default_is_noop(self):
+        """Outside any context the default NoOpMateria is active."""
+        assert isinstance(active_materia.get(), NoOpMateria)
+
+
+class TestDualBless:
+    """A single transmuter class can be registered in multiple materias."""
+
+    def test_in_sqlalchemy_registry(self):
+        assert City in sqlalchemy_materia.formulars
+
+    def test_in_redis_registry(self):
+        assert City in redis_materia.key_prefixes
+
+    def test_same_class_object(self):
+        # Both registries reference the very same class object.
+        assert sqlalchemy_materia.formulars[City] is CityORM
+        assert redis_materia.key_prefixes[City] == "City"
+
+
+class TestCacheAside:
+    """The classic cache-aside pattern: try Redis, fall back to SQL, then cache."""
+
+    def test_miss_then_hit(self, engine: Engine, fake_client: FakeClient):
+        paris_id = 1
+
+        # 1. Seed the database under sql_materia
+        with sqlalchemy_materia, Session(engine) as session, session.begin():
+            session.add(City(id=paris_id, name="Paris"))
+
+        # 2. Cache lookup misses
+        with redis_materia:
+            assert fake_client.tget(City, paris_id) is None
+
+        # 3. Fall back to SQL
+        with sqlalchemy_materia, Session(engine) as session:
+            from_db = session.get(City, paris_id)
+            assert from_db is not None
+            assert from_db.name == "Paris"
+
+        # 4. Populate the cache
+        with redis_materia:
+            fake_client.tset(from_db)
+
+        # 5. Now Redis hits
+        with redis_materia:
+            cached = fake_client.tget(City, paris_id)
+            assert cached is not None
+            assert cached.name == "Paris"
+            # Cached instance is decoupled from the SQL session — it's a fresh
+            # transmuter validated from the JSON payload.
+            assert cached is not from_db
+
+    def test_cache_invalidation_on_delete(
+        self, engine: Engine, fake_client: FakeClient
+    ):
+        rome_id = 2
+
+        with sqlalchemy_materia, Session(engine) as session, session.begin():
+            session.add(City(id=rome_id, name="Rome"))
+
+        # Cache it
+        with redis_materia:
+            fake_client.tset(City(id=rome_id, name="Rome"))
+            assert fake_client.tget(City, rome_id) is not None
+
+        # Invalidate the cache when SQL row is deleted
+        with sqlalchemy_materia, Session(engine) as session, session.begin():
+            session.execute(delete(CityORM).where(CityORM.id == rome_id))
+        with redis_materia:
+            fake_client.tdelete(City, rome_id)
+            assert fake_client.tget(City, rome_id) is None
+
+    def test_redis_lookup_inside_sql_context(
+        self, engine: Engine, fake_client: FakeClient
+    ):
+        """A common real-world shape: outer SQL session, inner Redis check."""
+        tokyo_id = 3
+
+        with sqlalchemy_materia, Session(engine) as session, session.begin():
+            session.add(City(id=tokyo_id, name="Tokyo"))
+
+            # Switch to redis briefly to populate the cache, without leaving
+            # the SQL transaction.
+            with redis_materia:
+                fake_client.tset(City(id=tokyo_id, name="Tokyo"))
+
+            # Active materia is restored to sql_materia after the inner block.
+            assert active_materia.get() is sqlalchemy_materia
+
+        # Cache survives across the SQL commit.
+        with redis_materia:
+            cached = fake_client.tget(City, tokyo_id)
+            assert cached is not None and cached.name == "Tokyo"
+
+
+class TestIsolation:
+    """Two materias must not leak state into each other."""
+
+    def test_redis_keys_unaware_of_sql_inserts(
+        self, engine: Engine, fake_client: FakeClient
+    ):
+        with sqlalchemy_materia, Session(engine) as session, session.begin():
+            session.add(City(name="Berlin"))
+
+        # Redis still empty — no automatic mirroring.
+        with redis_materia:
+            assert fake_client.tget(City, 9999) is None
+            # Native MGET on the empty redis namespace returns nothing.
+            assert fake_client.keys("City:*") == []
+
+    def test_sql_unaware_of_redis_writes(self, engine: Engine, fake_client: FakeClient):
+        # Write into Redis only
+        with redis_materia:
+            fake_client.tset(City(id=42424242, name="Atlantis"))
+
+        # SQL doesn't have it
+        with sqlalchemy_materia, Session(engine) as session:
+            assert (
+                session.execute(
+                    select(CityORM).where(CityORM.name == "Atlantis")
+                ).scalar_one_or_none()
+                is None
+            )
+
+
+class TestProviderResolution:
+    """``__transmuter_provider__`` and ``transmuter_formulars`` reflect the
+    *currently active* materia, not whatever was active when the instance was
+    built — these are dynamic properties.
+    """
+
+    def test_provider_under_sqlalchemy(self):
+        with sqlalchemy_materia:
+            assert City.__transmuter_provider__ is CityORM
+            # transmuter_formulars exposes the active materia's bidi map.
+            assert City in City.transmuter_formulars
+            assert City.transmuter_formulars[City] is CityORM
+
+    def test_provider_under_redis(self):
+        with redis_materia:
+            # redis_materia leaves ``formulars`` empty; no provider is exposed.
+            assert City.__transmuter_provider__ is None
+            assert City.transmuter_formulars == {}
+
+    def test_provider_under_noop(self):
+        # Default context (NoOp) — also no provider.
+        assert City.__transmuter_provider__ is None
+        assert City.transmuter_formulars == {}
+
+    def test_property_changes_when_active_materia_swaps(self):
+        """Same class, observed under different active materias."""
+        with sqlalchemy_materia:
+            assert City.__transmuter_provider__ is CityORM
+            with redis_materia:
+                # Same class, different active materia ⇒ different provider.
+                assert City.__transmuter_provider__ is None
+            # Restored after exit.
+            assert City.__transmuter_provider__ is CityORM
+
+
+class TestAutoProviderCreation:
+    """``model_formulate`` auto-constructs the ORM provider only when the
+    active materia has the transmuter blessed with a provider class.
+    """
+
+    def test_sqlalchemy_auto_creates_orm(self):
+        with sqlalchemy_materia:
+            city = City(id=3001, name="Athens")
+            # __transmuter_provided__ holds the auto-created ORM instance.
+            assert isinstance(city.__transmuter_provided__, CityORM)
+            assert city.__transmuter_provided__.id == 3001
+            assert city.__transmuter_provided__.name == "Athens"
+
+    def test_redis_does_not_auto_create_orm(self):
+        with redis_materia:
+            city = City(id=3002, name="Reykjavik")
+            assert city.__transmuter_provided__ is None
+
+    def test_noop_does_not_auto_create_orm(self):
+        city = City(id=3003, name="Quito")
+        assert city.__transmuter_provided__ is None
+
+
+class TestSameMateriaReentry:
+    def test_reentering_same_materia_raises(self):
+        """``with materia: with materia:`` is forbidden — must use the call
+        form for nested contexts."""
+        with redis_materia:
+            with pytest.raises(RuntimeError, match="already active"):
+                with redis_materia:
+                    pass
+
+    def test_call_form_is_safe_to_nest(self):
+        """``with redis_materia():`` creates a shallow copy that's safe to
+        nest, even under the original ``with redis_materia:`` block."""
+        with redis_materia:
+            with redis_materia():  # shallow copy
+                inner_active = active_materia.get()
+                assert isinstance(inner_active, RedisMateria)
+                # The copy shares state with the original (shallow).
+                assert inner_active.key_prefixes is redis_materia.key_prefixes
+            assert active_materia.get() is redis_materia
+
+
+class TestMultipleRedisMateriaInstances:
+    """Two ``RedisMateria`` instances are independent registries — same
+    transmuter class can carry different prefixes per materia."""
+
+    def test_independent_key_prefixes(self):
+        m1 = RedisMateria()
+        m2 = RedisMateria()
+
+        @m1.bless("namespace1")
+        @m2.bless("namespace2")
+        class Probe(BaseTransmuter):
+            id: Annotated[int, Identity] = Field(frozen=True)
+            value: str
+
+        assert m1.key_prefixes[Probe] == "namespace1"
+        assert m2.key_prefixes[Probe] == "namespace2"
+        # And the registries are physically separate dicts.
+        assert m1.key_prefixes is not m2.key_prefixes
+
+    def test_swapping_between_two_redis_materias(
+        self, fake_client: FakeClient
+    ):
+        """The active RedisMateria determines which key prefix Client uses."""
+        m1 = RedisMateria()
+        m2 = RedisMateria()
+
+        @m1.bless("alpha")
+        @m2.bless("beta")
+        class Item(BaseTransmuter):
+            id: Annotated[int, Identity] = Field(frozen=True)
+            value: str
+
+        with m1:
+            fake_client.tset(Item(id=1, value="a"))
+        with m2:
+            fake_client.tset(Item(id=1, value="b"))
+
+        # Both writes coexist under different namespaces.
+        assert fake_client.get("alpha:1") is not None
+        assert fake_client.get("beta:1") is not None
+
+        with m1:
+            got = fake_client.tget(Item, 1)
+            assert got is not None and got.value == "a"
+        with m2:
+            got = fake_client.tget(Item, 1)
+            assert got is not None and got.value == "b"
+
+
+class TestValidationContextIsolation:
+    """The SQL session's per-transaction validation_context must not be touched
+    by Redis operations, and Redis-rehydrated transmuters must not leak into
+    any active SQL validation_context.
+    """
+
+    def test_redis_ops_do_not_mutate_sql_validation_context(
+        self, engine: Engine, fake_client: FakeClient
+    ):
+        madrid_id = 1004
+
+        with sqlalchemy_materia, Session(engine) as session, session.begin():
+            session.add(City(id=madrid_id, name="Madrid"))
+
+        with sqlalchemy_materia, Session(engine) as session:
+            from_db = session.get(City, madrid_id)
+            assert from_db is not None
+
+            # The session's validation_context now binds the ORM provider to
+            # the wrapping transmuter.
+            ctx = session._validation_context
+            keys_before = set(ctx.keys())
+            assert from_db.__transmuter_provided__ in keys_before
+
+            # Switch to redis briefly — these ops must NOT mutate the SQL ctx.
+            with redis_materia:
+                fake_client.tset(from_db)
+                cached = fake_client.tget(City, madrid_id)
+                assert cached is not None
+
+            # Same dict object, same keys, same values.
+            assert session._validation_context is ctx
+            assert set(ctx.keys()) == keys_before
+            assert ctx[from_db.__transmuter_provided__] is from_db
+
+    def test_active_validated_contextvar_restored_after_redis_block(
+        self, engine: Engine, fake_client: FakeClient
+    ):
+        """Entering/leaving a redis context must not perturb the global
+        ``validated`` ContextVar that SQL Session has set up."""
+        with sqlalchemy_materia, Session(engine) as session:
+            sql_ctx = validated.get()
+            assert sql_ctx is session._validation_context
+
+            with redis_materia:
+                fake_client.tset(City(id=1005, name="Lima"))
+                # Inside the redis block the ContextVar is unchanged — Redis
+                # never touches `validated`.
+                assert validated.get() is sql_ctx
+
+            # And it is still pointing at the SQL session's context after exit.
+            assert validated.get() is sql_ctx
+
+    def test_redis_rehydrated_transmuter_has_no_provider(
+        self, engine: Engine, fake_client: FakeClient
+    ):
+        """A transmuter loaded from Redis JSON has no ORM provider attached,
+        so it cannot accidentally collide with a SQL session's validation_context."""
+        with redis_materia:
+            fake_client.tset(City(id=1006, name="Cairo"))
+
+        with redis_materia:
+            cached = fake_client.tget(City, 1006)
+        assert cached is not None
+        assert cached.__transmuter_provided__ is None
+
+    def test_redis_get_inside_sql_session_does_not_register_in_ctx(
+        self, engine: Engine, fake_client: FakeClient
+    ):
+        """A redis tget while a SQL session is open must not register the
+        rehydrated instance in the SQL session's validation_context."""
+        oslo_id = 1007
+
+        with redis_materia:
+            fake_client.tset(City(id=oslo_id, name="Oslo"))
+
+        with sqlalchemy_materia, Session(engine) as session:
+            keys_before = set(session._validation_context.keys())
+
+            with redis_materia:
+                cached = fake_client.tget(City, oslo_id)
+                assert cached is not None
+
+            # The redis-rehydrated instance is NOT in the SQL ctx, and the
+            # SQL ctx itself is unchanged.
+            assert set(session._validation_context.keys()) == keys_before
+            assert cached not in session._validation_context.values()

--- a/uv.lock
+++ b/uv.lock
@@ -25,9 +25,7 @@ name = "arcanus"
 version = "0.0.16"
 source = { editable = "." }
 dependencies = [
-    { name = "greenlet" },
     { name = "pydantic" },
-    { name = "sqlalchemy" },
 ]
 
 [package.optional-dependencies]
@@ -40,6 +38,10 @@ dev = [
 ]
 redis = [
     { name = "redis" },
+]
+sqlalchemy = [
+    { name = "greenlet" },
+    { name = "sqlalchemy" },
 ]
 
 [package.dev-dependencies]
@@ -56,22 +58,21 @@ dev = [
     { name = "pytest-codspeed" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
-    { name = "redis" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "asyncpg", marker = "extra == 'dev'", specifier = ">=0.28.0" },
-    { name = "greenlet", specifier = ">=3.2.4" },
+    { name = "greenlet", marker = "extra == 'sqlalchemy'", specifier = ">=3.2.4" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0.0" },
-    { name = "sqlalchemy", specifier = ">=2.0.0" },
+    { name = "sqlalchemy", marker = "extra == 'sqlalchemy'", specifier = ">=2.0.0" },
 ]
-provides-extras = ["dev", "redis"]
+provides-extras = ["dev", "sqlalchemy", "redis"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -87,7 +88,6 @@ dev = [
     { name = "pytest-codspeed", specifier = ">=4.2.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-xdist", specifier = ">=3.5.0" },
-    { name = "redis", specifier = ">=5.0.0" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "arcanus"
-version = "0.0.11"
+version = "0.0.16"
 source = { editable = "." }
 dependencies = [
     { name = "greenlet" },
@@ -38,11 +38,15 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
 ]
+redis = [
+    { name = "redis" },
+]
 
 [package.dev-dependencies]
 dev = [
     { name = "aiosqlite" },
     { name = "asyncpg" },
+    { name = "fakeredis" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "psycopg2-binary" },
@@ -52,6 +56,7 @@ dev = [
     { name = "pytest-codspeed" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
+    { name = "redis" },
 ]
 
 [package.metadata]
@@ -63,14 +68,16 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
+    { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "redis"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "aiosqlite", specifier = ">=0.19.0" },
     { name = "asyncpg", specifier = ">=0.30.0" },
+    { name = "fakeredis", specifier = ">=2.0.0" },
     { name = "mypy", specifier = ">=1.0.0" },
     { name = "pre-commit", specifier = ">=3.0.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
@@ -80,6 +87,16 @@ dev = [
     { name = "pytest-codspeed", specifier = ">=4.2.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-xdist", specifier = ">=3.5.0" },
+    { name = "redis", specifier = ">=5.0.0" },
+]
+
+[[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
 ]
 
 [[package]]
@@ -326,6 +343,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
+name = "fakeredis"
+version = "2.35.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "redis" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/50/b748233c02fa77e5105238190cc9bb58b852eb1c8b1d0763230d3a5b745a/fakeredis-2.35.1.tar.gz", hash = "sha256:5bae5eba7b9d93cb968944ac40936373cf2397ff71667d4b595df65c3d2e413f", size = 189118, upload-time = "2026-04-12T17:05:58.539Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/27/b8b057a23f7777177e92d3a602fd866751b6b45014964548997e92e048fd/fakeredis-2.35.1-py3-none-any.whl", hash = "sha256:67d97e11f562b7870e11e5c30cf182270bfb2dd37f6707dba47cc6d91628d1b9", size = 129678, upload-time = "2026-04-12T17:05:56.86Z" },
 ]
 
 [[package]]
@@ -935,6 +965,18 @@ wheels = [
 ]
 
 [[package]]
+name = "redis"
+version = "7.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/7f/3759b1d0d72b7c92f0d70ffd9dc962b7b7b5ee74e135f9d7d8ab06b8a318/redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad", size = 4943913, upload-time = "2026-03-24T09:14:37.53Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/3a/95deec7db1eb53979973ebd156f3369a72732208d1391cd2e5d127062a32/redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec", size = 409772, upload-time = "2026-03-24T09:14:35.968Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -945,6 +987,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4", size = 219990, upload-time = "2025-10-09T14:16:53.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl", hash = "sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd", size = 243393, upload-time = "2025-10-09T14:16:51.245Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds a new `arcanus.materia.redis` package with both sync and async Redis clients, context-managed materia registration, and comprehensive tests using `fakeredis`. Optional dependencies for Redis and SQLAlchemy are now properly isolated, and the test workflow is updated to install all extras for CI coverage.

**Redis materia and client implementation:**
- Added `arcanus.materia.redis` package, including `RedisMateria` for context-managed registration of transmuters, and `Client`/`AsyncClient` classes providing transmuter-aware helpers for storing, retrieving, and deleting objects in Redis. Key formatting supports custom prefixes and composite identities. [[1]](diffhunk://#diff-886a9793fd2d1a20129aa6f0254950f8d96a43f4e0163dbcb5b6a048dc1e338fR1-R15) [[2]](diffhunk://#diff-082dac3905cfb36033043661f128909ca4ca626c945bc7a7f72e59e2ee8e3327R1-R39) [[3]](diffhunk://#diff-9bded3e4f1fb655a5a907fdf6dcfcf07af36e830b27b4d38f3901b9784071ce3R1-R164)

**Testing and fixtures:**
- Introduced `tests/redis/conftest.py` with fixtures, fake clients using `fakeredis`, and shared transmuter classes for Redis-related tests.
- Added `tests/redis/test_async_client.py` with comprehensive async tests covering CRUD, key formatting, serialization, passthrough to native Redis methods, and error handling.

**Dependency and packaging improvements:**
- Moved `sqlalchemy` and `redis` dependencies to optional extras in `pyproject.toml`, and updated the `dev` dependencies to include test-only requirements such as `fakeredis` and SQL drivers. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L28-L30) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R39-R45) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R59-R67)
- Updated `arcanus.materia.sqlalchemy` and `arcanus.materia.redis` modules to raise informative `ImportError` messages if their respective extras are not installed. [[1]](diffhunk://#diff-aacb743384290e3579862290821c9ba13e39fc48ab27585c94d7adb3a78bb831R1-R8) [[2]](diffhunk://#diff-886a9793fd2d1a20129aa6f0254950f8d96a43f4e0163dbcb5b6a048dc1e338fR1-R15)

**Continuous integration:**
- Modified the test workflow to install all optional extras during CI runs, ensuring coverage for optional dependencies. [[1]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL66-R66) [[2]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL106-R106)