### PR TITLE
Fix nested criteria branches and frozen fields

### DIFF
--- a/arcanus/base.py
+++ b/arcanus/base.py
@@ -332,23 +332,20 @@ class Transmuter(metaclass=TransmuterTypingMetaclass):
             # Normal validation
             instance: Self = handler(data)
             if provider is not None:
-                model_fields = cls.__pydantic_fields__
-                excludes = set(cls.model_associations.keys()) | set(
+                skipped_fields = set(cls.model_associations.keys()) | set(
                     getattr(cls, "__pydantic_computed_fields__", {}).keys()
                 )
-                if isinstance(instance, BaseModel):
-                    included = instance.model_dump(exclude=excludes, by_alias=True)
-                else:
-                    included = get_cached_adapter(cls).dump_python(
-                        instance, exclude=excludes, by_alias=True
-                    )
-                excluded = {
-                    model_fields[name].alias or name: getattr(instance, name)
-                    for name in cls.__pydantic_fields__.keys()
-                    - cls.model_associations.keys()
-                    if model_fields[name].exclude and not model_fields[name].frozen
-                }
-                provided = provider(**included, **excluded)
+                provider_values: dict[str, Any] = {}
+                for name, field_info in cls.__pydantic_fields__.items():
+                    if name in skipped_fields:
+                        continue
+                    try:
+                        provider_values[field_info.alias or name] = getattr(
+                            instance, name
+                        )
+                    except AttributeError:
+                        continue
+                provided = provider(**provider_values)
                 provided.transmuter_proxy = instance
                 object.__setattr__(instance, "__transmuter_provided__", provided)
                 object.__setattr__(instance, "__transmuter_revalidating__", False)
@@ -783,24 +780,20 @@ class BaseTransmuter(Transmuter, BaseModel, metaclass=TransmuterMetaclass):
             instance = super().model_construct(_fields_set=_fields_set, **inputs)
 
             if provider is not None:
-                pydantic_fields = cls.__pydantic_fields__
-                excludes = set(cls.model_associations.keys()) | set(
+                skipped_fields = set(cls.model_associations.keys()) | set(
                     getattr(cls, "__pydantic_computed_fields__", {}).keys()
                 )
-                if isinstance(instance, BaseModel):
-                    included = instance.model_dump(exclude=excludes, by_alias=True)
-                else:
-                    included = get_cached_adapter(cls).dump_python(
-                        instance, exclude=excludes, by_alias=True
-                    )
-                excluded = {
-                    pydantic_fields[name].alias or name: getattr(instance, name)
-                    for name in cls.__pydantic_fields__.keys()
-                    - cls.model_associations.keys()
-                    if pydantic_fields[name].exclude
-                    and not pydantic_fields[name].frozen
-                }
-                provided = provider(**included, **excluded)
+                provider_values: dict[str, Any] = {}
+                for name, field_info in cls.__pydantic_fields__.items():
+                    if name in skipped_fields:
+                        continue
+                    try:
+                        provider_values[field_info.alias or name] = getattr(
+                            instance, name
+                        )
+                    except AttributeError:
+                        continue
+                provided = provider(**provider_values)
                 provided.transmuter_proxy = instance
                 object.__setattr__(instance, "__transmuter_provided__", provided)
                 object.__setattr__(instance, "__transmuter_revalidating__", False)

--- a/arcanus/base.py
+++ b/arcanus/base.py
@@ -346,7 +346,7 @@ class Transmuter(metaclass=TransmuterTypingMetaclass):
                     model_fields[name].alias or name: getattr(instance, name)
                     for name in cls.__pydantic_fields__.keys()
                     - cls.model_associations.keys()
-                    if model_fields[name].exclude
+                    if model_fields[name].exclude and not model_fields[name].frozen
                 }
                 provided = provider(**included, **excluded)
                 provided.transmuter_proxy = instance
@@ -798,6 +798,7 @@ class BaseTransmuter(Transmuter, BaseModel, metaclass=TransmuterMetaclass):
                     for name in cls.__pydantic_fields__.keys()
                     - cls.model_associations.keys()
                     if pydantic_fields[name].exclude
+                    and not pydantic_fields[name].frozen
                 }
                 provided = provider(**included, **excluded)
                 provided.transmuter_proxy = instance

--- a/arcanus/criteria.py
+++ b/arcanus/criteria.py
@@ -463,7 +463,7 @@ class Criteria(ModelGeneric[P]):
         return expressions[0] if len(expressions) == 1 else and_(expressions)
 
 
-class NestedCriteria(Criteria[P]):
+class NestedCriteriaBranch(Criteria[P]):
     @classmethod
     def __get_generic_model_field_definitions__(
         cls, generic_model: TransmuterType
@@ -533,6 +533,31 @@ class NestedCriteria(Criteria[P]):
         if not expressions:
             return None
         return expressions[0] if len(expressions) == 1 else and_(expressions)
+
+
+class NestedCriteria(NestedCriteriaBranch[P]):
+    @classmethod
+    def __get_generic_model_field_definitions__(
+        cls, generic_model: TransmuterType
+    ) -> dict[str, Any]:
+        fields = super().__get_generic_model_field_definitions__(generic_model)
+        branch_model = cast(
+            type[NestedCriteriaBranch[P]],
+            cast(Any, NestedCriteriaBranch)[generic_model],
+        )
+        fields["and_"] = (
+            tuple.__class_getitem__((branch_model, ...)) | None,
+            Field(default=None, alias="and"),
+        )
+        fields["or_"] = (
+            tuple.__class_getitem__((branch_model, ...)) | None,
+            Field(default=None, alias="or"),
+        )
+        fields["not_"] = (
+            branch_model | None,
+            Field(default=None, alias="not"),
+        )
+        return fields
 
 
 class Ordering(RootModel[tuple[str, ...]], Generic[P]):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcanus"
-version = "0.1.0"
+version = "0.0.20"
 description = "Sticker to bind pydantic schemas with various datasources"
 authors = [
     {name = "arcanus", email = "luhui19970305@hotmail.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcanus"
-version = "0.0.19"
+version = "0.1.0"
 description = "Sticker to bind pydantic schemas with various datasources"
 authors = [
     {name = "arcanus", email = "luhui19970305@hotmail.com"},

--- a/tests/test_criteria.py
+++ b/tests/test_criteria.py
@@ -60,6 +60,53 @@ def test_nested_criteria_accepts_one_layer_relationship_criteria():
     }
 
 
+def test_nested_criteria_bool_branches_accept_one_layer_relationships():
+    criteria_model = NestedCriteria[Author]
+
+    criteria = criteria_model.model_validate(
+        {
+            "and": [
+                {"name": {"eq": "Ada"}},
+                {"books": {"title": {"eq": "Notes"}}},
+            ],
+        }
+    )
+
+    assert criteria.model_dump(mode="json", by_alias=True, exclude_none=True) == {
+        "and": [
+            {"name": {"eq": "Ada"}},
+            {"books": {"title": {"eq": "Notes"}}},
+        ]
+    }
+    with sqlalchemy_materia:
+        expression = criteria.expression
+
+    assert expression is not None
+    assert expression.dump() == {
+        "and": [
+            {"name": {"eq": "Ada"}},
+            {"books": {"title": {"eq": "Notes"}}},
+        ]
+    }
+
+
+def test_nested_criteria_bool_branches_keep_deeper_logic_scalar():
+    criteria_model = NestedCriteria[Author]
+
+    with pytest.raises(ValidationError):
+        criteria_model.model_validate(
+            {
+                "and": [
+                    {
+                        "and": [
+                            {"books": {"title": {"eq": "Notes"}}},
+                        ]
+                    },
+                ],
+            }
+        )
+
+
 def test_nested_cursor_round_trips_relationship_criteria():
     with sqlalchemy_materia:
         bookmark = CursorBookmark[Author].from_expression(
@@ -77,6 +124,28 @@ def test_nested_cursor_round_trips_relationship_criteria():
     assert dumped == {"books": {"title": {"eq": "Notes"}}}
     assert restored.limit == 10
     assert restored.bookmark.order_by == ("-id",)
+
+
+def test_nested_cursor_round_trips_scalar_and_relationship_criteria():
+    with sqlalchemy_materia:
+        bookmark = CursorBookmark[Author].from_expression(
+            order_bys=(Author["id"].desc(),)
+        )
+        cursor = NestedCursor[Author].from_expression(
+            expression=(Author["name"] == "Ada")
+            & Author["books"].any(Book["title"] == "Notes"),
+            bookmark=bookmark,
+            limit=10,
+        )
+        restored = NestedCursor[Author](str(cursor))
+
+    assert restored.criteria is not None
+    assert restored.criteria.model_dump(mode="json", by_alias=True, exclude_none=True) == {
+        "and": [
+            {"name": {"eq": "Ada"}},
+            {"books": {"title": {"eq": "Notes"}}},
+        ]
+    }
 
 
 def test_criteria_generics_require_transmuter_types():

--- a/tests/test_criteria.py
+++ b/tests/test_criteria.py
@@ -140,7 +140,9 @@ def test_nested_cursor_round_trips_scalar_and_relationship_criteria():
         restored = NestedCursor[Author](str(cursor))
 
     assert restored.criteria is not None
-    assert restored.criteria.model_dump(mode="json", by_alias=True, exclude_none=True) == {
+    assert restored.criteria.model_dump(
+        mode="json", by_alias=True, exclude_none=True
+    ) == {
         "and": [
             {"name": {"eq": "Ada"}},
             {"books": {"title": {"eq": "Notes"}}},

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "arcanus"
-version = "0.0.18"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "arcanus"
-version = "0.1.0"
+version = "0.0.20"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
- Bump Arcanus to `0.0.20`.
- Split nested criteria into a first-level `NestedCriteria` plus scalar deeper branches, allowing top-level `and`/`or`/`not` branches to contain one layer of relationship criteria without recursively nesting relationship schemas.
- Add regression coverage for nested bool branches, deeper scalar-only validation, and nested cursor round-trips containing both scalar and relationship criteria.