### PR TITLE
[codex] Support text range criteria operators

### DIFF
--- a/arcanus/criteria.py
+++ b/arcanus/criteria.py
@@ -75,6 +75,10 @@ class BaseCriteria(BaseModel, Generic[T]):
 
 
 class TextCriteria(BaseCriteria[S]):
+    lt: S | None = None
+    le: S | None = None
+    gt: S | None = None
+    ge: S | None = None
     contains: S | None = None
     not_contains: S | None = None
     starts_with: S | None = None
@@ -85,6 +89,10 @@ class TextCriteria(BaseCriteria[S]):
 
     criteria_operators: ClassVar[tuple[tuple[str, str], ...]] = (
         *BaseCriteria.criteria_operators,
+        ("lt", "lt"),
+        ("le", "le"),
+        ("gt", "gt"),
+        ("ge", "ge"),
         ("contains", "contains"),
         ("not_contains", "not_contains"),
         ("starts_with", "starts_with"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcanus"
-version = "0.0.20"
+version = "0.0.21"
 description = "Sticker to bind pydantic schemas with various datasources"
 authors = [
     {name = "arcanus", email = "luhui19970305@hotmail.com"},

--- a/tests/sqlalchemy/sync/test_session.py
+++ b/tests/sqlalchemy/sync/test_session.py
@@ -873,6 +873,58 @@ class TestSessionHelpers:
                 author.name for author in manual_results
             ]
 
+    def test_list_with_text_range_criteria(self, engine: Engine):
+        """Text criteria range operators compile through SQLAlchemy string columns."""
+        criteria_model = Criteria[Author]
+        payload = {
+            "name": {"gt": "Text Range B", "le": "Text Range G"},
+            "field": {"eq": "Astronomy"},
+        }
+        orders = (Author["name"].asc(),)
+
+        with Session(engine) as session:
+            session.add_all(
+                [
+                    Author(name="Text Range A", field="Astronomy"),
+                    Author(name="Text Range C", field="Astronomy"),
+                    Author(name="Text Range G", field="Astronomy"),
+                    Author(name="Text Range Z", field="Astronomy"),
+                    Author(name="Text Range C", field="Robotics"),
+                ]
+            )
+            session.flush()
+
+            criteria = criteria_model.model_validate(payload)
+            assert criteria.expression is not None
+            criteria_expression = criteria.expression
+            compiled_expression = criteria_expression(
+                sqlalchemy_materia.expression_compiler
+            )
+            compiled_order_bys = tuple(
+                order_by(sqlalchemy_materia.expression_compiler) for order_by in orders
+            )
+
+            manual_results = (
+                session.execute(
+                    select(Author).where(compiled_expression).order_by(*compiled_order_bys)
+                )
+                .scalars()
+                .all()
+            )
+            list_results = session.list(
+                Author,
+                expressions=[criteria_expression],
+                order_bys=orders,
+            )
+
+            assert [author.name for author in manual_results] == [
+                "Text Range C",
+                "Text Range G",
+            ]
+            assert [author.name for author in list_results] == [
+                author.name for author in manual_results
+            ]
+
     def test_partitions_yields_chunks(self, engine: Engine):
         """Test partitions yields results in chunks."""
         with Session(engine) as session:

--- a/tests/sqlalchemy/sync/test_session.py
+++ b/tests/sqlalchemy/sync/test_session.py
@@ -906,7 +906,9 @@ class TestSessionHelpers:
 
             manual_results = (
                 session.execute(
-                    select(Author).where(compiled_expression).order_by(*compiled_order_bys)
+                    select(Author)
+                    .where(compiled_expression)
+                    .order_by(*compiled_order_bys)
                 )
                 .scalars()
                 .all()

--- a/tests/test_criteria.py
+++ b/tests/test_criteria.py
@@ -171,9 +171,6 @@ def test_criteria_validation_rejects_wrong_value_types_and_operators():
         criteria_model.model_validate({"id": {"lt": "not-an-int"}})
 
     with pytest.raises(ValidationError):
-        criteria_model.model_validate({"name": {"lt": "Ada"}})
-
-    with pytest.raises(ValidationError):
         criteria_model.model_validate({"and": [{"name": {"like": 123}}]})
 
     with pytest.raises(ValidationError):
@@ -200,6 +197,32 @@ def test_literal_fields_use_exact_value_criteria():
 
     with pytest.raises(ValidationError):
         criteria_model.model_validate({"field": {"eq": "Painting"}})
+
+
+def test_text_criteria_accepts_range_operators():
+    criteria_model = Criteria[Author]
+
+    criteria = criteria_model.model_validate(
+        {"name": {"lt": "Grace", "le": "Grace", "gt": "Ada", "ge": "Ada"}}
+    )
+    name_criteria: TextCriteria[str] | None = getattr(criteria, "name")
+
+    assert name_criteria is not None
+    assert name_criteria.lt == "Grace"
+    assert name_criteria.le == "Grace"
+    assert name_criteria.gt == "Ada"
+    assert name_criteria.ge == "Ada"
+    with sqlalchemy_materia:
+        expression = criteria.expression
+    assert expression is not None
+    assert expression.dump() == {
+        "and": [
+            {"name": {"lt": "Grace"}},
+            {"name": {"le": "Grace"}},
+            {"name": {"gt": "Ada"}},
+            {"name": {"ge": "Ada"}},
+        ]
+    }
 
 
 def test_criteria_validation_accepts_nested_logical_fields():

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "arcanus"
-version = "0.0.20"
+version = "0.0.21"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Add `lt`, `le`, `gt`, and `ge` support to `TextCriteria`.
- Cover text range criteria parsing and SQLAlchemy string-column filtering.
- Bump package version to `0.0.21`.

## Validation
- `uv run ruff check arcanus/criteria.py tests/test_criteria.py tests/sqlalchemy/sync/test_session.py`
- `uv run pytest tests/test_criteria.py::test_text_criteria_accepts_range_operators tests/test_criteria.py::test_criteria_validation_rejects_wrong_value_types_and_operators tests/sqlalchemy/sync/test_session.py::TestSessionHelpers::test_list_with_text_range_criteria -q`

Replaces closed PR #36, which was created from the wrong branch history.