### PR TITLE
[codex] simplify cursor criteria

### DIFF
--- a/arcanus/__init__.py
+++ b/arcanus/__init__.py
@@ -20,6 +20,7 @@ from arcanus.base import (
     TransmuterType,
 )
 from arcanus.criteria import (
+    BookmarkCriteria,
     Criteria,
     Cursor,
     NestedCriteria,
@@ -37,6 +38,7 @@ __all__ = [
     "Transmuter",
     "TransmuterType",
     "Criteria",
+    "BookmarkCriteria",
     "Cursor",
     "NestedCriteria",
     "NestedCursor",

--- a/arcanus/criteria.py
+++ b/arcanus/criteria.py
@@ -7,8 +7,10 @@ from functools import cached_property
 from types import UnionType, prepare_class
 from typing import (
     Any,
+    Callable,
     ClassVar,
     Generic,
+    Iterable,
     Iterator,
     Literal,
     Self,
@@ -40,6 +42,7 @@ from arcanus.base import TransmuterType, transmuter_type
 from arcanus.expression import Column, Expression, Order, and_, or_
 
 P = TypeVar("P")
+R = TypeVar("R")
 T = TypeVar("T")
 S = TypeVar("S", bound=str)
 N = TypeVar("N", bound=float | int | UUID | datetime | bool)
@@ -53,6 +56,14 @@ CriteriaExample = dict[str, CriteriaExampleValue | list[CriteriaExampleValue]]
 CRITERIA_CURSOR_VERSION = 1
 
 
+class _ClassProperty(Generic[R]):
+    def __init__(self, fget: Callable[[Any], R]) -> None:
+        self.fget = fget
+
+    def __get__(self, instance: object, owner: type[Any] | None = None) -> R:
+        return self.fget(owner or type(instance))
+
+
 class BaseCriteria(BaseModel, Generic[T]):
     model_config = ConfigDict(
         populate_by_name=True,
@@ -62,19 +73,24 @@ class BaseCriteria(BaseModel, Generic[T]):
     )
 
     eq: T | None = None
+
+    criteria_operators: ClassVar[tuple[tuple[str, str], ...]] = (("eq", "eq"),)
+
+
+class ExactCriteria(BaseCriteria[T]):
     ne: T | None = None
     in_: tuple[T, ...] | None = Field(default=None, alias="in")
     not_in: tuple[T, ...] | None = None
 
     criteria_operators: ClassVar[tuple[tuple[str, str], ...]] = (
-        ("eq", "eq"),
+        *BaseCriteria.criteria_operators,
         ("ne", "ne"),
         ("in_", "in_"),
         ("not_in", "not_in"),
     )
 
 
-class TextCriteria(BaseCriteria[S]):
+class TextCriteria(ExactCriteria[S]):
     lt: S | None = None
     le: S | None = None
     gt: S | None = None
@@ -88,7 +104,7 @@ class TextCriteria(BaseCriteria[S]):
     not_like: S | None = None
 
     criteria_operators: ClassVar[tuple[tuple[str, str], ...]] = (
-        *BaseCriteria.criteria_operators,
+        *ExactCriteria.criteria_operators,
         ("lt", "lt"),
         ("le", "le"),
         ("gt", "gt"),
@@ -103,18 +119,29 @@ class TextCriteria(BaseCriteria[S]):
     )
 
 
-class NumericCriteria(BaseCriteria[N]):
+class NumericCriteria(ExactCriteria[N]):
     lt: N | None = None
     le: N | None = None
     gt: N | None = None
     ge: N | None = None
 
     criteria_operators: ClassVar[tuple[tuple[str, str], ...]] = (
-        *BaseCriteria.criteria_operators,
+        *ExactCriteria.criteria_operators,
         ("lt", "lt"),
         ("le", "le"),
         ("gt", "gt"),
         ("ge", "ge"),
+    )
+
+
+class BookmarkValueCriteria(BaseCriteria[T]):
+    lt: T | None = None
+    gt: T | None = None
+
+    criteria_operators: ClassVar[tuple[tuple[str, str], ...]] = (
+        *BaseCriteria.criteria_operators,
+        ("lt", "lt"),
+        ("gt", "gt"),
     )
 
 
@@ -261,7 +288,7 @@ class ModelGeneric(BaseModel, Generic[P]):
         return {}
 
 
-class Criteria(ModelGeneric[P]):
+class ScalarCriteria(ModelGeneric[P]):
     model_config = ConfigDict(
         populate_by_name=True,
         validate_by_alias=True,
@@ -270,11 +297,9 @@ class Criteria(ModelGeneric[P]):
         extra="forbid",
     )
 
-    and_: tuple[Criteria[P], ...] | None = Field(default=None, alias="and")
-    or_: tuple[Criteria[P], ...] | None = Field(default=None, alias="or")
-    not_: Criteria[P] | None = Field(default=None, alias="not")
-
-    criteria_type_mapping: ClassVar[dict[type[Any], type[BaseCriteria[Any]]]] = {
+    criteria_type_mapping: ClassVar[
+        dict[CriteriaValueType, type[BaseCriteria[Any]]]
+    ] = {
         str: TextCriteria[str],
         UUID: NumericCriteria[UUID],
         int: NumericCriteria[int],
@@ -288,6 +313,54 @@ class Criteria(ModelGeneric[P]):
         cls, generic_model: TransmuterType
     ) -> dict[str, Any]:
         scalar_fields: dict[str, Any] = {}
+
+        for name, info in generic_model.__pydantic_fields__.items():
+            if name in generic_model.model_associations:
+                continue
+            # Normalize scalar field annotations before mapping them to criteria types.
+            annotation = info.annotation
+            origin = get_origin(annotation)
+            if origin is UnionType or str(origin) == "typing.Union":
+                annotation = next(
+                    (arg for arg in get_args(annotation) if arg is not type(None)),
+                    object,
+                )
+                origin = get_origin(annotation)
+            if origin is Literal:
+                literal_values = get_args(annotation)
+                if not literal_values:
+                    continue
+                criteria_type = cast(
+                    type[BaseCriteria[Any]], cast(Any, ExactCriteria)[annotation]
+                )
+                scalar_fields[name] = (
+                    criteria_type | None,
+                    Field(default=None),
+                )
+                continue
+            else:
+                try:
+                    if is_association(cast(type[Any], annotation)):
+                        annotation = object
+                except TypeError:
+                    annotation = object
+            if isinstance(annotation, type) and annotation in cls.criteria_type_mapping:
+                criteria_value_type = cast(CriteriaValueType, annotation)
+                criteria_type = cast(
+                    type[BaseCriteria[Any]],
+                    cls.criteria_type_mapping[criteria_value_type],
+                )
+                scalar_fields[name] = (
+                    criteria_type | None,
+                    Field(default=None),
+                )
+
+        return scalar_fields
+
+    @classmethod
+    def __get_generic_model_examples__(
+        cls, generic_model: TransmuterType
+    ) -> dict[str, CriteriaExample]:
         scalar_examples: dict[str, CriteriaExample] = {}
 
         def example_value(annotation: CriteriaValueType) -> CriteriaExampleValue:
@@ -318,7 +391,6 @@ class Criteria(ModelGeneric[P]):
         for name, info in generic_model.__pydantic_fields__.items():
             if name in generic_model.model_associations:
                 continue
-            # Normalize scalar field annotations before mapping them to criteria types.
             annotation = info.annotation
             origin = get_origin(annotation)
             if origin is UnionType or str(origin) == "typing.Union":
@@ -332,13 +404,9 @@ class Criteria(ModelGeneric[P]):
                 if not literal_values:
                     continue
                 criteria_type = cast(
-                    type[BaseCriteria[Any]], cast(Any, BaseCriteria)[annotation]
+                    type[BaseCriteria[Any]], cast(Any, ExactCriteria)[annotation]
                 )
                 example = literal_values[0]
-                scalar_fields[name] = (
-                    criteria_type | None,
-                    Field(default=None),
-                )
                 scalar_examples[name] = criteria_example(
                     criteria_type,
                     example
@@ -353,16 +421,51 @@ class Criteria(ModelGeneric[P]):
                 except TypeError:
                     annotation = object
             if isinstance(annotation, type) and annotation in cls.criteria_type_mapping:
-                criteria_type = cls.criteria_type_mapping[annotation]
                 criteria_value_type = cast(CriteriaValueType, annotation)
-                scalar_fields[name] = (
-                    criteria_type | None,
-                    Field(default=None),
+                criteria_type = cast(
+                    type[BaseCriteria[Any]],
+                    cls.criteria_type_mapping[criteria_value_type],
                 )
                 scalar_examples[name] = criteria_example(
                     criteria_type, example_value(criteria_value_type)
                 )
+        return scalar_examples
 
+    @cached_property
+    def expressions(self) -> tuple[Expression[bool], ...]:
+        expressions: list[Expression[bool]] = []
+        generic_model = type(self).generic_model
+        reserved = {"limit", "offset", "order_by", "cursor"}
+
+        for name, value in self:
+            if value is None or name in reserved:
+                continue
+            if isinstance(value, BaseCriteria):
+                column = cast(
+                    Column[CriteriaValue],
+                    generic_model[name],
+                )
+                column_expressions = [
+                    column.operate(operator, operator_value)
+                    for attribute, operator in value.criteria_operators
+                    if (operator_value := getattr(value, attribute)) is not None
+                ]
+                expressions.extend(column_expressions)
+
+        return tuple(expressions)
+
+
+class Criteria(ScalarCriteria[P]):
+    and_: tuple[Criteria[P], ...] | None = Field(default=None, alias="and")
+    or_: tuple[Criteria[P], ...] | None = Field(default=None, alias="or")
+    not_: Criteria[P] | None = Field(default=None, alias="not")
+
+    @classmethod
+    def __get_generic_model_field_definitions__(
+        cls, generic_model: TransmuterType
+    ) -> dict[str, Any]:
+        scalar_fields = super().__get_generic_model_field_definitions__(generic_model)
+        scalar_examples = cls.__get_generic_model_examples__(generic_model)
         first_example = next(iter(scalar_examples.items()), None)
         second_example = next(
             (
@@ -416,59 +519,29 @@ class Criteria(ModelGeneric[P]):
         return fields
 
     @cached_property
-    def expression(self) -> Expression[bool] | None:
-        expressions: list[Expression[bool]] = []
-        generic_model = type(self).generic_model
-        reserved = {"and_", "or_", "not_", "limit", "offset", "order_by", "cursor"}
-
-        for name, value in self:
-            if value is None or name in reserved:
-                continue
-            if isinstance(value, BaseCriteria):
-                column = cast(
-                    Column[CriteriaValue],
-                    generic_model[name],  # pyright: ignore[reportIndexIssue]
-                )
-                column_expressions = [
-                    column.operate(operator, operator_value)
-                    for attribute, operator in value.criteria_operators
-                    if (operator_value := getattr(value, attribute)) is not None
-                ]
-                if not column_expressions:
-                    continue
-                expressions.append(
-                    column_expressions[0]
-                    if len(column_expressions) == 1
-                    else and_(column_expressions)
-                )
+    def expressions(self) -> tuple[Expression[bool], ...]:
+        expressions = list(super().expressions)
 
         if self.and_:
             for criteria in self.and_:
-                expression = criteria.expression
-                if expression is not None:
-                    expressions.append(expression)
+                expressions.extend(criteria.expressions)
 
         if self.or_:
             or_expressions: list[Expression[bool]] = []
             for criteria in self.or_:
-                expression = criteria.expression
-                if expression is not None:
-                    or_expressions.append(expression)
+                branch_expressions = criteria.expressions
+                if len(branch_expressions) == 1:
+                    or_expressions.append(branch_expressions[0])
+                elif branch_expressions:
+                    or_expressions.append(and_(branch_expressions))
             if or_expressions:
-                expressions.append(
-                    or_expressions[0]
-                    if len(or_expressions) == 1
-                    else or_(or_expressions)
-                )
+                expressions.append(or_(or_expressions))
 
         if self.not_:
-            expression = self.not_.expression
-            if expression is not None:
+            for expression in self.not_.expressions:
                 expressions.append(~expression)
 
-        if not expressions:
-            return None
-        return expressions[0] if len(expressions) == 1 else and_(expressions)
+        return tuple(expressions)
 
 
 class NestedCriteriaBranch(Criteria[P]):
@@ -509,11 +582,8 @@ class NestedCriteriaBranch(Criteria[P]):
         return fields
 
     @cached_property
-    def expression(self) -> Expression[bool] | None:
-        expressions: list[Expression[bool]] = []
-        scalar_expression = super().expression
-        if scalar_expression is not None:
-            expressions.append(scalar_expression)
+    def expressions(self) -> tuple[Expression[bool], ...]:
+        expressions = list(super().expressions)
 
         generic_model = type(self).generic_model
         try:
@@ -524,8 +594,7 @@ class NestedCriteriaBranch(Criteria[P]):
             criteria = getattr(self, name, None)
             if not isinstance(criteria, Criteria):
                 continue
-            expression = criteria.expression
-            if expression is not None:
+            for expression in criteria.expressions:
                 column = cast(Column[CriteriaValue], generic_model[name])
                 annotation = annotations.get(
                     name, generic_model.model_associations[name].annotation
@@ -538,9 +607,7 @@ class NestedCriteriaBranch(Criteria[P]):
                     column.any(expression) if is_collection else column.has(expression)
                 )
 
-        if not expressions:
-            return None
-        return expressions[0] if len(expressions) == 1 else and_(expressions)
+        return tuple(expressions)
 
 
 class NestedCriteria(NestedCriteriaBranch[P]):
@@ -572,23 +639,32 @@ class Ordering(RootModel[tuple[str, ...]], Generic[P]):
     model_config = ConfigDict(frozen=True)
 
     generic_model: ClassVar[TransmuterType]
-    generic_cache: ClassVar[dict[tuple[type[Any], TransmuterType], type[Any]]] = {}
+    generic_cache: ClassVar[
+        dict[tuple[type[BaseModel], TransmuterType], type[BaseModel]]
+    ] = {}
 
-    def __class_getitem__(cls, generic_model: object | tuple[object, ...]) -> type[Any]:
+    def __class_getitem__(
+        cls, generic_model: object | tuple[object, ...]
+    ) -> type[BaseModel] | _forward_ref.PydanticRecursiveRef:
         if isinstance(generic_model, tuple):
             if len(generic_model) != 1:
                 raise TypeError(f"{cls.__name__} expects exactly one generic model")
             generic_model = generic_model[0]
 
         if not isinstance(generic_model, type):
-            return cast(Any, super().__class_getitem__(cast(Any, generic_model)))
-        generic_model = transmuter_type(generic_model)
+            return cast(
+                type[BaseModel] | _forward_ref.PydanticRecursiveRef,
+                super().__class_getitem__(cast(Any, generic_model)),
+            )
+        generic_model_type = transmuter_type(generic_model)
 
-        cache_key = (cls, generic_model)
+        cache_key = (cls, generic_model_type)
         if cache_key in cls.generic_cache:
             return cls.generic_cache[cache_key]
 
-        criteria_model = cast(type[Criteria[P]], cast(Any, Criteria)[generic_model])
+        criteria_model = cast(
+            type[Criteria[P]], cast(Any, Criteria)[generic_model_type]
+        )
         order_by_allowed = tuple(
             order
             for name in criteria_model.__pydantic_fields__
@@ -601,15 +677,15 @@ class Ordering(RootModel[tuple[str, ...]], Generic[P]):
             root_type = tuple.__class_getitem__((order_by_item, ...))
 
         model = cast(
-            type[Any],
+            type[BaseModel],
             create_model(
-                f"{cls.__name__}[{generic_model.__name__}]",
+                f"{cls.__name__}[{generic_model_type.__name__}]",
                 __base__=cls,
                 __module__=cls.__module__,
                 root=(root_type, Field(default=())),
             ),
         )
-        model.generic_model = generic_model
+        cast(Any, model).generic_model = generic_model_type
         cls.generic_cache[cache_key] = model
         return model
 
@@ -644,44 +720,81 @@ class Ordering(RootModel[tuple[str, ...]], Generic[P]):
         return self.root == other
 
 
-class CursorBookmark(ModelGeneric[P]):
-    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True, extra="forbid")
-
-    criteria: Criteria[P] | None = None
-    order_by: Ordering[P] | None = None
+class BookmarkCriteria(ScalarCriteria[P]):
+    criteria_type_mapping: ClassVar[
+        dict[CriteriaValueType, type[BaseCriteria[Any]]]
+    ] = {
+        str: BookmarkValueCriteria[str],
+        UUID: BookmarkValueCriteria[UUID],
+        int: BookmarkValueCriteria[int],
+        float: BookmarkValueCriteria[float],
+        bool: BookmarkValueCriteria[bool],
+        datetime: BookmarkValueCriteria[datetime],
+    }
 
     @classmethod
     def __get_generic_model_field_definitions__(
         cls, generic_model: TransmuterType
     ) -> dict[str, Any]:
-        criteria_model = cast(type[Criteria[P]], cast(Any, Criteria)[generic_model])
-        order_by_model = cast(type[Ordering[P]], cast(Any, Ordering)[generic_model])
-        fields: dict[str, Any] = {
-            "criteria": (criteria_model | None, Field(default=None)),
-            "order_by": (order_by_model | None, Field(default=None)),
-        }
+        fields = super().__get_generic_model_field_definitions__(generic_model)
+        bookmark_model = cast(
+            type[BookmarkCriteria[P]], cast(Any, BookmarkCriteria)[generic_model]
+        )
+        fields["and_"] = (
+            tuple.__class_getitem__((bookmark_model, ...)) | None,
+            Field(default=None, alias="and"),
+        )
+        fields["or_"] = (
+            tuple.__class_getitem__((bookmark_model, ...)) | None,
+            Field(default=None, alias="or"),
+        )
         return fields
 
-    @classmethod
-    def from_expression(
-        cls,
-        *,
-        expression: Expression[bool] | None = None,
-        order_bys: tuple[Order[CriteriaValue], ...] = (),
-    ) -> Self:
-        generics = cls.__pydantic_generic_metadata__["args"]
-        generic_model = generics[0] if generics else None
-        if not isinstance(generic_model, type):
-            raise PydanticCustomError(
-                "invalid_cursor", "Cursor bookmark generic model is not specified"
-            )
+    @cached_property
+    def expression(self) -> Expression[bool] | None:
+        expressions = list(super().expressions)
 
-        return cls.model_validate(
-            {
-                "criteria": expression.dump() if expression is not None else None,
-                "order_by": tuple(order_by.dump() for order_by in order_bys),
-            }
-        )
+        if and_criteria := getattr(self, "and_", None):
+            for criteria in and_criteria:
+                expression = criteria.expression
+                if expression is not None:
+                    expressions.append(expression)
+
+        if or_criteria := getattr(self, "or_", None):
+            or_expressions: list[Expression[bool]] = []
+            for criteria in or_criteria:
+                expression = criteria.expression
+                if expression is not None:
+                    or_expressions.append(expression)
+            if or_expressions:
+                expressions.append(or_(or_expressions))
+
+        if not expressions:
+            return None
+        return expressions[0] if len(expressions) == 1 else and_(expressions)
+
+
+def bookmark_criteria_fields(bookmark: BookmarkCriteria[Any]) -> set[str]:
+    fields: set[str] = set()
+    for name, value in bookmark:
+        if value is None:
+            continue
+        if name in {"and_", "or_"}:
+            for branch in value:
+                fields.update(bookmark_criteria_fields(branch))
+            continue
+        if name == "not_":
+            raise PydanticCustomError(
+                "invalid_cursor",
+                "Invalid cursor bookmark: Cursor bookmark cannot contain not",
+            )
+        if not isinstance(value, BaseCriteria):
+            raise PydanticCustomError(
+                "invalid_cursor",
+                "Invalid cursor bookmark: Cursor bookmark can only contain scalar criteria",
+            )
+        fields.add(name)
+    return fields
 
 
 class CursorPayload(BaseModel, Generic[P]):
@@ -691,16 +804,15 @@ class CursorPayload(BaseModel, Generic[P]):
         extra="forbid",
     )
 
-    version: Literal[1] = 1
+    version: Literal[1] = CRITERIA_CURSOR_VERSION
     entity: str
     criteria: Criteria[P] | None = None
     limit: int | None = Field(default=100, ge=1)
-    offset: int | None = Field(default=None, ge=0)
-    order_by: Ordering[P] | None = None
-    bookmark: CursorBookmark[P]
+    order_by: Ordering[P]
+    bookmark: BookmarkCriteria[P]
 
     @model_validator(mode="after")
-    def validate_entity(self) -> Self:
+    def validate_payload(self) -> Self:
         arguments = (
             getattr(type(self), "__pydantic_generic_metadata__", {}).get("args") or ()
         )
@@ -711,15 +823,29 @@ class CursorPayload(BaseModel, Generic[P]):
                 raise PydanticCustomError(
                     "invalid_cursor", "Cursor entity does not match requested entity"
                 )
+        if not self.order_by:
+            raise PydanticCustomError("invalid_cursor", "Cursor requires order_by")
+        order_names = tuple(order[1:] for order in self.order_by)
+        order_name_set = set(order_names)
+        bookmark_names = bookmark_criteria_fields(self.bookmark)
+        if not bookmark_names <= order_name_set:
+            raise PydanticCustomError(
+                "invalid_cursor",
+                "Cursor bookmark fields must be present in order_by",
+            )
         return self
 
 
 class NestedCursorPayload(CursorPayload[P]):
-    criteria: NestedCriteria[P] | None = None
+    criteria: NestedCriteria[P] | None = None  # pyright: ignore[reportIncompatibleVariableOverride]
 
 
 class Cursor(RootModel[str], Generic[P]):
-    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+        ignored_types=(_ClassProperty,),
+    )
 
     payload_type: ClassVar[type[BaseModel]] = CursorPayload
     criteria_type: ClassVar[type[BaseModel]] = Criteria
@@ -759,22 +885,26 @@ class Cursor(RootModel[str], Generic[P]):
         self._payload = payload
         return self
 
-    @classmethod
-    def from_expression(
-        cls,
-        *,
-        bookmark: CursorBookmark[P],
-        limit: int | None = None,
-        offset: int | None = None,
-        expression: Expression[bool] | None = None,
-        order_bys: tuple[Order[CriteriaValue], ...] = (),
-    ) -> Self:
+    @_ClassProperty
+    def generic_model(cls) -> type[P]:
         generics = cls.__pydantic_generic_metadata__["args"]
         generic_model = generics[0] if generics else None
         if not isinstance(generic_model, type):
             raise PydanticCustomError(
                 "invalid_cursor", "Cursor generic model is not specified"
             )
+        return generic_model
+
+    @classmethod
+    def from_expressions(
+        cls,
+        *,
+        expressions: Iterable[Expression[bool]] | None = None,
+        bookmark: Expression[bool] | None = None,
+        limit: int | None = None,
+        order_bys: tuple[Order[CriteriaValue], ...],
+    ) -> Self:
+        generic_model = cls.generic_model
 
         # Mypy cannot express runtime Pydantic generic indexing here.
         criteria_model = cast(
@@ -784,20 +914,33 @@ class Cursor(RootModel[str], Generic[P]):
             type[CursorPayload[P]], cast(Any, cls.payload_type)[generic_model]
         )
         order_by_model = cast(type[Ordering[P]], cast(Any, Ordering)[generic_model])
+        criteria_expressions = tuple(expressions or ())
+        criteria_expression = (
+            None
+            if not criteria_expressions
+            else criteria_expressions[0]
+            if len(criteria_expressions) == 1
+            else and_(criteria_expressions)
+        )
         criteria = (
-            criteria_model.model_validate(expression.dump())
-            if expression is not None
+            criteria_model.model_validate(criteria_expression.dump())
+            if criteria_expression is not None
             else None
         )
-        order_by = order_by_model.from_orders(order_bys) if order_bys else None
+        order_by = order_by_model.from_orders(order_bys)
+        bookmark_model = cast(
+            type[BookmarkCriteria[P]], cast(Any, BookmarkCriteria)[generic_model]
+        )
+        bookmark_criteria = bookmark_model.model_validate(
+            bookmark.dump() if bookmark is not None else {}
+        )
 
         payload = payload_model(
             entity=generic_model.__name__,
             criteria=criteria,
             limit=limit,
-            offset=offset,
             order_by=order_by,
-            bookmark=bookmark,
+            bookmark=bookmark_criteria,
         )
 
         payload_json = payload.model_dump_json(by_alias=True, exclude_none=True)
@@ -805,6 +948,28 @@ class Cursor(RootModel[str], Generic[P]):
         cursor = cls.model_construct(root=token)
         cursor._payload = payload
         return cursor
+
+    @classmethod
+    def bookmark_from_item(
+        cls,
+        item: P,
+        order_bys: tuple[Order[CriteriaValue], ...],
+    ) -> Expression[bool]:
+        if not order_bys:
+            raise PydanticCustomError(
+                "invalid_cursor", "Cursor bookmark requires order_by"
+            )
+        clauses: list[Expression[bool]] = []
+        equalities: list[Expression[bool]] = []
+        for order_by in order_bys:
+            column = order_by.column
+            value = getattr(item, column.field_name)
+            comparison = column < value if order_by.descending else column > value
+            clauses.append(
+                comparison if not equalities else and_((*equalities, comparison))
+            )
+            equalities.append(column == value)
+        return clauses[0] if len(clauses) == 1 else or_(clauses)
 
     @property
     def payload(self) -> CursorPayload[P]:
@@ -827,15 +992,11 @@ class Cursor(RootModel[str], Generic[P]):
         return self.payload.limit
 
     @property
-    def offset(self) -> int | None:
-        return self.payload.offset
-
-    @property
-    def order_by(self) -> Ordering[P] | None:
+    def order_by(self) -> Ordering[P]:
         return self.payload.order_by
 
     @property
-    def bookmark(self) -> CursorBookmark[P]:
+    def bookmark(self) -> BookmarkCriteria[P]:
         return self.payload.bookmark
 
 
@@ -857,7 +1018,7 @@ class Page(BaseModel, Generic[T]):
 
     items: tuple[T, ...]
     total: int = 0
-    next_cursor: str | None
+    next_cursor: str
     has_more: bool
 
     @overload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcanus"
-version = "0.0.21"
+version = "0.0.22"
 description = "Sticker to bind pydantic schemas with various datasources"
 authors = [
     {name = "arcanus", email = "luhui19970305@hotmail.com"},

--- a/tests/sqlalchemy/async/test_async_operations.py
+++ b/tests/sqlalchemy/async/test_async_operations.py
@@ -960,10 +960,10 @@ class TestAsyncSessionHelpers:
             ]
 
     @pytest.mark.asyncio
-    async def test_async_list_with_json_criteria_expression_and_compiler_chain(
+    async def test_async_list_with_json_criteria_expression(
         self, async_engine: AsyncEngine
     ):
-        """Test JSON criteria values can drive arcanus and SQLAlchemy expressions."""
+        """Test JSON criteria values can drive AsyncSession list expressions."""
         criteria_model = Criteria[Author]
         payload = {
             "name": {"starts_with": "Async Criteria Chain"},
@@ -991,32 +991,13 @@ class TestAsyncSessionHelpers:
                 mode="json", by_alias=True, exclude_none=True
             ) == criteria.model_dump(mode="json", by_alias=True, exclude_none=True)
 
-            assert criteria.expression is not None
-            criteria_expression = criteria.expression
-            compiled_expression = criteria_expression(
-                sqlalchemy_materia.expression_compiler
-            )
-            compiled_order_bys = tuple(
-                order_by(sqlalchemy_materia.expression_compiler) for order_by in orders
-            )
-
-            manual_result = await session.execute(
-                select(Author)
-                .where(compiled_expression)
-                .order_by(*compiled_order_bys)
-                .limit(limit)
-            )
             list_results = await session.list(
                 Author,
-                expressions=[criteria_expression],
+                expressions=criteria.expressions,
                 order_bys=orders,
                 limit=limit,
             )
 
-            assert [author.name for author in manual_result.scalars().all()] == [
-                "Async Criteria Chain C",
-                "Async Criteria Chain B",
-            ]
             assert [author.name for author in list_results] == [
                 "Async Criteria Chain C",
                 "Async Criteria Chain B",
@@ -1248,7 +1229,7 @@ class TestAsyncSessionHelpers:
             await session.flush()
 
             criteria = criteria_model.model_validate_json(json.dumps(payload))
-            assert criteria.expression is not None
+            assert criteria.expressions
 
             all_results = []
             async for partition in session.partitions(
@@ -1256,7 +1237,7 @@ class TestAsyncSessionHelpers:
                 size=2,
                 limit=limit,
                 order_bys=orders,
-                expressions=[criteria.expression],
+                expressions=criteria.expressions,
             ):
                 all_results.extend(partition)
 

--- a/tests/sqlalchemy/async/test_pagination.py
+++ b/tests/sqlalchemy/async/test_pagination.py
@@ -4,9 +4,8 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from arcanus import Criteria, Cursor, Page
-from arcanus.criteria import CursorBookmark
 from arcanus.materia.sqlalchemy import AsyncSession
-from tests.transmuters import Author, Book, BookDetail, Category, Publisher
+from tests.transmuters import Author
 
 
 class TestAsyncCursorPagination:
@@ -14,11 +13,9 @@ class TestAsyncCursorPagination:
     async def test_async_cursor_pagination_with_expressions_orders_and_count(
         self, async_engine: AsyncEngine
     ):
-        """Test cursor payloads can drive expression pagination outside Session."""
-        criteria_model = Criteria[Author]
-        criteria = criteria_model.model_validate(
+        criteria = Criteria[Author].model_validate(
             {
-                "name": {"starts_with": "Async Cursor Page"},
+                "name": {"starts_with": "Async Cursor Manual Page"},
                 "field": {"eq": "Science Fiction"},
             }
         )
@@ -27,342 +24,141 @@ class TestAsyncCursorPagination:
 
         async with AsyncSession(async_engine) as session:
             authors = [
-                Author(name="Async Cursor Page A", field="Science Fiction"),
-                Author(name="Async Cursor Page B", field="Science Fiction"),
-                Author(name="Async Cursor Page C", field="Science Fiction"),
-                Author(name="Async Cursor Page D", field="Science Fiction"),
-                Author(name="Async Cursor Page Outside", field="History"),
+                Author(name="Async Cursor Manual Page A", field="Science Fiction"),
+                Author(name="Async Cursor Manual Page B", field="Science Fiction"),
+                Author(name="Async Cursor Manual Page C", field="Science Fiction"),
+                Author(name="Async Cursor Manual Page D", field="Science Fiction"),
+                Author(name="Async Cursor Manual Page Outside", field="History"),
             ]
             session.add_all(authors)
             await session.flush()
             for author in authors:
                 author.revalidate()
 
-            assert criteria.expression is not None
-            criteria_expression = criteria.expression
-            total = await session.count(Author, expressions=[criteria_expression])
+            total = await session.count(Author, expressions=criteria.expressions)
             first_items = await session.list(
                 Author,
-                limit=limit,
+                limit=limit + 1,
                 order_bys=orders,
-                expressions=[criteria_expression],
+                expressions=criteria.expressions,
             )
-            last_author_id = first_items[-1].id
-            assert last_author_id is not None
-            first_cursor = Cursor[Author].from_expression(
-                expression=criteria_expression,
-                bookmark=CursorBookmark[Author].from_expression(
-                    expression=Author["id"] > last_author_id,
-                    order_bys=orders,
-                ),
+            first_page_items = tuple(first_items[:limit])
+            first_bookmark = Cursor[Author].bookmark_from_item(
+                first_page_items[-1], orders
+            )
+            first_cursor = Cursor[Author].from_expressions(
+                expressions=criteria.expressions,
+                bookmark=first_bookmark,
                 order_bys=orders,
                 limit=limit,
             )
             first_page = Page(
-                items=tuple(first_items),
+                items=first_page_items,
                 total=total,
                 next_cursor=str(first_cursor),
-                has_more=total > len(first_items),
+                has_more=len(first_items) > limit,
             )
 
-            assert first_page.next_cursor is not None
             decoded = Cursor[Author](first_page.next_cursor)
             assert decoded.criteria is not None
-            decoded_criteria_expression = decoded.criteria.expression
-            assert decoded_criteria_expression is not None
-            assert decoded_criteria_expression.dump() == criteria_expression.dump()
-            assert decoded.payload.limit == limit
-            assert decoded.payload.order_by == ("+id",)
-            assert decoded.bookmark.criteria
-            assert decoded.bookmark.criteria.model_dump(
-                mode="json", by_alias=True, exclude_none=True
-            ) == {"id": {"gt": last_author_id}}
-            assert decoded.bookmark.order_by == ("+id",)
-            decoded_bookmark_expression = decoded.bookmark.criteria.expression
-            assert decoded_bookmark_expression is not None
+            bookmark_expression = decoded.bookmark.expression
             second_items = await session.list(
                 Author,
-                limit=decoded.payload.limit,
-                order_bys=orders,
-                expressions=[decoded_criteria_expression, decoded_bookmark_expression],
+                limit=decoded.limit + 1 if decoded.limit is not None else None,
+                order_bys=decoded.order_by.orders,
+                expressions=(
+                    *decoded.criteria.expressions,
+                    *(
+                        (bookmark_expression,)
+                        if bookmark_expression is not None
+                        else ()
+                    ),
+                ),
+            )
+            second_page_items = tuple(second_items[: decoded.limit])
+            second_bookmark = (
+                Cursor[Author].bookmark_from_item(
+                    second_page_items[-1], decoded.order_by.orders
+                )
+                if second_page_items
+                else decoded.bookmark.expression
+            )
+            second_cursor = Cursor[Author].from_expressions(
+                expressions=decoded.criteria.expressions,
+                bookmark=second_bookmark,
+                order_bys=decoded.order_by.orders,
+                limit=decoded.limit,
             )
             second_page = Page(
-                items=tuple(second_items),
+                items=second_page_items,
                 total=total,
-                next_cursor=str(first_cursor),
-                has_more=total > len(first_page) + len(second_items),
+                next_cursor=str(second_cursor),
+                has_more=len(second_items) > limit,
             )
 
             assert total == 4
-            assert first_page.total == 4
-            assert [author.name for author in first_page] == [
-                "Async Cursor Page A",
-                "Async Cursor Page B",
-            ]
             assert first_page.has_more is True
-            assert second_page.total == 4
-            assert [author.name for author in second_page] == [
-                "Async Cursor Page C",
-                "Async Cursor Page D",
+            assert [author.name for author in first_page] == [
+                "Async Cursor Manual Page A",
+                "Async Cursor Manual Page B",
             ]
+            assert decoded.order_by == ("+id",)
+            assert decoded.bookmark.model_dump(
+                mode="json", by_alias=True, exclude_none=True
+            ) == {"id": {"gt": authors[1].id}}
             assert second_page.has_more is False
+            assert second_page.next_cursor is not None
+            assert [author.name for author in second_page] == [
+                "Async Cursor Manual Page C",
+                "Async Cursor Manual Page D",
+            ]
 
     @pytest.mark.asyncio
-    async def test_async_cursor_pagination_with_reverse_non_id_order(
+    async def test_async_cursor_pagination_with_empty_result_has_empty_bookmark(
         self, async_engine: AsyncEngine
     ):
-        """Test user-supplied bookmark expressions with descending non-id orders."""
         criteria = Criteria[Author].model_validate(
-            {
-                "name": {"starts_with": "Async Reverse Cursor"},
-            }
+            {"name": {"starts_with": "Async Empty Manual Cursor"}}
         )
         limit = 2
-        orders = (Author["name"].desc(),)
+        orders = (Author["id"].desc(),)
 
         async with AsyncSession(async_engine) as session:
-            authors = [
-                Author(name="Async Reverse Cursor A", field="Quantum Physics"),
-                Author(name="Async Reverse Cursor B", field="Quantum Physics"),
-                Author(name="Async Reverse Cursor C", field="Quantum Physics"),
-                Author(name="Async Reverse Cursor D", field="Quantum Physics"),
-            ]
-            session.add_all(authors)
-            await session.flush()
-            for author in authors:
-                author.revalidate()
-
-            assert criteria.expression is not None
-            criteria_expression = criteria.expression
+            total = await session.count(Author, expressions=criteria.expressions)
             first_items = await session.list(
                 Author,
-                limit=limit,
+                limit=limit + 1,
                 order_bys=orders,
-                expressions=[criteria_expression],
+                expressions=criteria.expressions,
             )
-            cursor = Cursor[Author].from_expression(
-                bookmark=CursorBookmark[Author].from_expression(
-                    expression=Author["id"] > 0,
-                    order_bys=orders,
-                ),
-                expression=criteria_expression,
-                order_bys=orders,
-                limit=limit,
+            first_page_items = tuple(first_items[:limit])
+            bookmark = (
+                Cursor[Author].bookmark_from_item(first_page_items[-1], orders)
+                if first_page_items
+                else None
             )
-            decoded = Cursor[Author](str(cursor))
-            assert decoded.criteria is not None
-            assert decoded.criteria.model_dump(
-                mode="json", by_alias=True, exclude_none=True
-            ) == criteria.model_dump(mode="json", by_alias=True, exclude_none=True)
-            assert first_items[-1].id is not None
-            next_cursor = Cursor[Author].from_expression(
-                expression=criteria_expression,
-                bookmark=CursorBookmark[Author].from_expression(
-                    expression=Author["id"] < first_items[-1].id,
-                    order_bys=orders,
-                ),
+            cursor = Cursor[Author].from_expressions(
+                expressions=criteria.expressions,
+                bookmark=bookmark,
                 order_bys=orders,
                 limit=limit,
             )
-            decoded = Cursor[Author](str(next_cursor))
-            assert decoded.criteria is not None
-            decoded_criteria_expression = decoded.criteria.expression
-            assert decoded_criteria_expression is not None
-            assert decoded.bookmark.criteria
-            decoded_bookmark_expression = decoded.bookmark.criteria.expression
-            assert decoded_bookmark_expression is not None
-
-            next_items = await session.list(
-                Author,
-                limit=decoded.payload.limit,
-                order_bys=orders,
-                expressions=[decoded_criteria_expression, decoded_bookmark_expression],
-            )
-
-            assert [author.name for author in first_items] == [
-                "Async Reverse Cursor D",
-                "Async Reverse Cursor C",
-            ]
-            assert [author.name for author in next_items] == [
-                "Async Reverse Cursor B",
-                "Async Reverse Cursor A",
-            ]
-
-    @pytest.mark.asyncio
-    async def test_async_cursor_pagination_with_complex_relationship_filters(
-        self, async_engine: AsyncEngine
-    ):
-        """Test decoded cursors drive list and partitions with relationship filters."""
-        criteria = Criteria[Book].model_validate(
-            {
-                "and": [
-                    {"title": {"starts_with": "Async Rel Cursor"}},
-                    {"year": {"ge": 2020}},
-                ],
-                "or": [
-                    {"title": {"contains": "Match"}},
-                    {"title": {"contains": "Next"}},
-                ],
-                "not": {"title": {"contains": "Skip"}},
-            }
-        )
-        limit = 1
-        orders = (Book["id"].asc(),)
-
-        async with AsyncSession(async_engine) as session:
-            publisher = Publisher(name="Async Rel Cursor Publisher", country="USA")
-            matching_author = Author(
-                name="Async Rel Cursor Author", field="Astrophysics"
-            )
-            other_author = Author(name="Async Rel Cursor Other Author", field="History")
-            category = Category(
-                name="Async Rel Cursor Category", description="Pagination"
-            )
-            other_category = Category(
-                name="Async Rel Cursor Other Category", description="Pagination"
-            )
-
-            first_book = Book(title="Async Rel Cursor Match A", year=2024)
-            first_book.author.value = matching_author
-            first_book.publisher.value = publisher
-            first_book.detail.value = BookDetail(
-                isbn="978-8888840001",
-                pages=310,
-                abstract="first async cursor match",
-            )
-            first_book.categories.append(category)
-
-            second_book = Book(title="Async Rel Cursor Next B", year=2025)
-            second_book.author.value = matching_author
-            second_book.publisher.value = publisher
-            second_book.detail.value = BookDetail(
-                isbn="978-8888840002",
-                pages=420,
-                abstract="second async cursor match",
-            )
-            second_book.categories.append(category)
-
-            wrong_author_book = Book(
-                title="Async Rel Cursor Match Wrong Author", year=2024
-            )
-            wrong_author_book.author.value = other_author
-            wrong_author_book.publisher.value = publisher
-            wrong_author_book.detail.value = BookDetail(
-                isbn="978-8888840003",
-                pages=510,
-                abstract="wrong author",
-            )
-            wrong_author_book.categories.append(category)
-
-            wrong_category_book = Book(
-                title="Async Rel Cursor Match Wrong Category", year=2024
-            )
-            wrong_category_book.author.value = matching_author
-            wrong_category_book.publisher.value = publisher
-            wrong_category_book.detail.value = BookDetail(
-                isbn="978-8888840004",
-                pages=610,
-                abstract="wrong category",
-            )
-            wrong_category_book.categories.append(other_category)
-
-            skipped_book = Book(title="Async Rel Cursor Skip Match", year=2024)
-            skipped_book.author.value = matching_author
-            skipped_book.publisher.value = publisher
-            skipped_book.detail.value = BookDetail(
-                isbn="978-8888840005",
-                pages=710,
-                abstract="skipped by not criteria",
-            )
-            skipped_book.categories.append(category)
-
-            session.add_all(
-                [
-                    first_book,
-                    second_book,
-                    wrong_author_book,
-                    wrong_category_book,
-                    skipped_book,
-                ]
-            )
-            await session.flush()
-            first_book.revalidate()
-            second_book.revalidate()
-
-            assert criteria.expression is not None
-            criteria_expression = criteria.expression
-            relationship_expression = (
-                Book["author"].has(Author["field"] == "Astrophysics")
-                & Book["categories"].any(
-                    Category["name"] == "Async Rel Cursor Category"
-                )
-                & Book["detail"].has(BookDetail["pages"] >= 300)
-            )
-            expressions = [criteria_expression, relationship_expression]
-            total = await session.count(Book, expressions=expressions)
-            first_items = await session.list(
-                Book,
-                limit=limit,
-                order_bys=orders,
-                expressions=expressions,
-            )
-            last_book_id = first_items[-1].id
-            assert last_book_id is not None
-            cursor = Cursor[Book].from_expression(
-                expression=criteria_expression,
-                bookmark=CursorBookmark[Book].from_expression(
-                    expression=Book["id"] > last_book_id,
-                    order_bys=orders,
-                ),
-                order_bys=orders,
-                limit=limit,
-            )
-            decoded = Cursor[Book](str(cursor))
-            assert decoded.criteria is not None
-            decoded_criteria_expression = decoded.criteria.expression
-            assert decoded_criteria_expression is not None
-            assert decoded.bookmark.criteria
-            decoded_bookmark_expression = decoded.bookmark.criteria.expression
-            assert decoded_bookmark_expression is not None
-            next_expressions = [
-                decoded_criteria_expression,
-                decoded_bookmark_expression,
-                relationship_expression,
-            ]
-            next_list_items = await session.list(
-                Book,
-                limit=decoded.payload.limit,
-                order_bys=orders,
-                expressions=next_expressions,
-            )
-            next_page = Page(
-                items=tuple(next_list_items),
+            page = Page(
+                items=first_page_items,
                 total=total,
                 next_cursor=str(cursor),
-                has_more=total > len(first_items) + len(next_list_items),
+                has_more=len(first_items) > limit,
             )
-            next_partition_items = [
-                item
-                async for partition in session.partitions(
-                    Book,
-                    size=1,
-                    limit=decoded.payload.limit,
-                    order_bys=orders,
-                    expressions=next_expressions,
-                )
-                for item in partition
-            ]
 
-            assert total == 2
-            assert next_page.total == 2
-            assert next_page.has_more is False
-            assert decoded.criteria is not None
-            assert decoded.criteria.expression is not None
-            assert decoded.criteria.expression.dump() == criteria_expression.dump()
-            assert decoded.payload.limit == limit
-            assert decoded.payload.order_by == ("+id",)
-            assert [book.title for book in first_items] == ["Async Rel Cursor Match A"]
-            assert [book.title for book in next_page] == ["Async Rel Cursor Next B"]
-            assert [book.title for book in next_partition_items] == [
-                "Async Rel Cursor Next B"
-            ]
+            decoded = Cursor[Author](page.next_cursor)
+
+            assert page.items == ()
+            assert page.total == 0
+            assert page.has_more is False
+            assert decoded.bookmark.expression is None
+            assert (
+                decoded.bookmark.model_dump(
+                    mode="json", by_alias=True, exclude_none=True
+                )
+                == {}
+            )

--- a/tests/sqlalchemy/sync/test_pagination.py
+++ b/tests/sqlalchemy/sync/test_pagination.py
@@ -3,462 +3,243 @@ from __future__ import annotations
 from sqlalchemy import Engine
 
 from arcanus import Criteria, Cursor, Page
-from arcanus.criteria import CursorBookmark
 from arcanus.materia.sqlalchemy import Session
-from tests.transmuters import Author, Book, BookDetail, Category, Publisher
+from tests.transmuters import Author
 
 
 class TestCursorPagination:
     def test_cursor_pagination_with_expressions_orders_and_count(self, engine: Engine):
-        """Test cursor payloads can drive expression pagination outside Session."""
-        criteria_model = Criteria[Author]
-        payload = {
-            "name": {"starts_with": "Cursor Page"},
-            "field": {"eq": "Science Fiction"},
-        }
+        criteria = Criteria[Author].model_validate(
+            {
+                "name": {"starts_with": "Cursor Manual Page"},
+                "field": {"eq": "Science Fiction"},
+            }
+        )
         limit = 2
         orders = (Author["id"].asc(),)
-        criteria = criteria_model.model_validate(payload)
 
         with Session(engine) as session:
             authors = [
-                Author(name="Cursor Page A", field="Science Fiction"),
-                Author(name="Cursor Page B", field="Science Fiction"),
-                Author(name="Cursor Page C", field="Science Fiction"),
-                Author(name="Cursor Page D", field="Science Fiction"),
-                Author(name="Cursor Page Outside", field="History"),
+                Author(name="Cursor Manual Page A", field="Science Fiction"),
+                Author(name="Cursor Manual Page B", field="Science Fiction"),
+                Author(name="Cursor Manual Page C", field="Science Fiction"),
+                Author(name="Cursor Manual Page D", field="Science Fiction"),
+                Author(name="Cursor Manual Page Outside", field="History"),
             ]
             session.add_all(authors)
             session.flush()
             for author in authors:
                 author.revalidate()
 
-            assert criteria.expression is not None
-            criteria_expression = criteria.expression
-            total = session.count(Author, expressions=[criteria_expression])
+            total = session.count(Author, expressions=criteria.expressions)
             first_items = session.list(
                 Author,
-                limit=limit,
+                limit=limit + 1,
                 order_bys=orders,
-                expressions=[criteria_expression],
+                expressions=criteria.expressions,
             )
-            last_author_id = first_items[-1].id
-            assert last_author_id is not None
-            first_cursor = Cursor[Author].from_expression(
-                expression=criteria_expression,
-                bookmark=CursorBookmark[Author].from_expression(
-                    expression=Author["id"] > last_author_id,
-                    order_bys=orders,
-                ),
+            first_page_items = tuple(first_items[:limit])
+            first_bookmark = Cursor[Author].bookmark_from_item(
+                first_page_items[-1], orders
+            )
+            first_cursor = Cursor[Author].from_expressions(
+                expressions=criteria.expressions,
+                bookmark=first_bookmark,
                 order_bys=orders,
                 limit=limit,
             )
             first_page = Page(
-                items=tuple(first_items),
+                items=first_page_items,
                 total=total,
                 next_cursor=str(first_cursor),
-                has_more=total > len(first_items),
+                has_more=len(first_items) > limit,
             )
 
-            assert first_page.next_cursor is not None
             decoded = Cursor[Author](first_page.next_cursor)
             assert decoded.criteria is not None
-            decoded_criteria_expression = decoded.criteria.expression
-            assert decoded_criteria_expression is not None
-            assert decoded_criteria_expression.dump() == criteria_expression.dump()
-            assert decoded.payload.limit == limit
-            assert decoded.payload.order_by == ("+id",)
-            assert decoded.bookmark.criteria
-            assert decoded.bookmark.criteria.model_dump(
-                mode="json", by_alias=True, exclude_none=True
-            ) == {"id": {"gt": last_author_id}}
-            assert decoded.bookmark.order_by == ("+id",)
-            decoded_bookmark_expression = decoded.bookmark.criteria.expression
-            assert decoded_bookmark_expression is not None
+            bookmark_expression = decoded.bookmark.expression
             second_items = session.list(
                 Author,
-                limit=decoded.payload.limit,
-                order_bys=orders,
-                expressions=[decoded_criteria_expression, decoded_bookmark_expression],
+                limit=decoded.limit + 1 if decoded.limit is not None else None,
+                order_bys=decoded.order_by.orders,
+                expressions=(
+                    *decoded.criteria.expressions,
+                    *(
+                        (bookmark_expression,)
+                        if bookmark_expression is not None
+                        else ()
+                    ),
+                ),
+            )
+            second_page_items = tuple(second_items[: decoded.limit])
+            second_bookmark = (
+                Cursor[Author].bookmark_from_item(
+                    second_page_items[-1], decoded.order_by.orders
+                )
+                if second_page_items
+                else decoded.bookmark.expression
+            )
+            second_cursor = Cursor[Author].from_expressions(
+                expressions=decoded.criteria.expressions,
+                bookmark=second_bookmark,
+                order_bys=decoded.order_by.orders,
+                limit=decoded.limit,
             )
             second_page = Page(
-                items=tuple(second_items),
+                items=second_page_items,
                 total=total,
-                next_cursor=str(first_cursor),
-                has_more=total > len(first_page) + len(second_items),
+                next_cursor=str(second_cursor),
+                has_more=len(second_items) > limit,
             )
 
             assert total == 4
-            assert first_page.total == 4
-            assert [author.name for author in first_page] == [
-                "Cursor Page A",
-                "Cursor Page B",
-            ]
             assert first_page.has_more is True
-            assert second_page.total == 4
-            assert [author.name for author in second_page] == [
-                "Cursor Page C",
-                "Cursor Page D",
+            assert [author.name for author in first_page] == [
+                "Cursor Manual Page A",
+                "Cursor Manual Page B",
             ]
+            assert decoded.order_by == ("+id",)
+            assert decoded.bookmark.model_dump(
+                mode="json", by_alias=True, exclude_none=True
+            ) == {"id": {"gt": authors[1].id}}
             assert second_page.has_more is False
+            assert second_page.next_cursor is not None
+            assert [author.name for author in second_page] == [
+                "Cursor Manual Page C",
+                "Cursor Manual Page D",
+            ]
 
-    def test_cursor_pagination_with_reverse_non_id_order(self, engine: Engine):
-        """Test user-supplied bookmark expressions with descending non-id orders."""
-        criteria_model = Criteria[Author]
-        payload = {
-            "name": {"starts_with": "Reverse Cursor"},
-        }
+    def test_cursor_pagination_with_descending_user_order(self, engine: Engine):
+        criteria = Criteria[Author].model_validate(
+            {"name": {"starts_with": "Descending Manual Cursor"}}
+        )
         limit = 2
         orders = (Author["name"].desc(),)
-        criteria = criteria_model.model_validate(payload)
 
         with Session(engine) as session:
             authors = [
-                Author(name="Reverse Cursor A", field="Quantum Physics"),
-                Author(name="Reverse Cursor B", field="Quantum Physics"),
-                Author(name="Reverse Cursor C", field="Quantum Physics"),
-                Author(name="Reverse Cursor D", field="Quantum Physics"),
+                Author(name="Descending Manual Cursor A", field="Physics"),
+                Author(name="Descending Manual Cursor B", field="Physics"),
+                Author(name="Descending Manual Cursor C", field="Physics"),
+                Author(name="Descending Manual Cursor D", field="Physics"),
             ]
             session.add_all(authors)
             session.flush()
             for author in authors:
                 author.revalidate()
 
-            assert criteria.expression is not None
-            criteria_expression = criteria.expression
             first_items = session.list(
                 Author,
-                limit=limit,
+                limit=limit + 1,
                 order_bys=orders,
-                expressions=[criteria_expression],
+                expressions=criteria.expressions,
             )
-            cursor = Cursor[Author].from_expression(
-                bookmark=CursorBookmark[Author].from_expression(
-                    expression=Author["id"] > 0,
-                    order_bys=orders,
-                ),
-                expression=criteria_expression,
+            first_page_items = tuple(first_items[:limit])
+            bookmark = Cursor[Author].bookmark_from_item(first_page_items[-1], orders)
+            cursor = Cursor[Author].from_expressions(
+                expressions=criteria.expressions,
+                bookmark=bookmark,
                 order_bys=orders,
                 limit=limit,
             )
             decoded = Cursor[Author](str(cursor))
             assert decoded.criteria is not None
-            assert decoded.criteria.model_dump(
-                mode="json", by_alias=True, exclude_none=True
-            ) == criteria.model_dump(mode="json", by_alias=True, exclude_none=True)
-            assert first_items[-1].id is not None
-            next_cursor = Cursor[Author].from_expression(
-                expression=criteria_expression,
-                bookmark=CursorBookmark[Author].from_expression(
-                    expression=Author["id"] < first_items[-1].id,
-                    order_bys=orders,
+            bookmark_expression = decoded.bookmark.expression
+
+            second_items = session.list(
+                Author,
+                limit=decoded.limit + 1 if decoded.limit is not None else None,
+                order_bys=decoded.order_by.orders,
+                expressions=(
+                    *decoded.criteria.expressions,
+                    *(
+                        (bookmark_expression,)
+                        if bookmark_expression is not None
+                        else ()
+                    ),
                 ),
-                order_bys=orders,
-                limit=limit,
             )
-            decoded = Cursor[Author](str(next_cursor))
-            assert decoded.criteria is not None
-            decoded_criteria_expression = decoded.criteria.expression
-            assert decoded_criteria_expression is not None
-            assert decoded.bookmark.criteria
-            decoded_bookmark_expression = decoded.bookmark.criteria.expression
-            assert decoded_bookmark_expression is not None
-
-            next_items = session.list(
-                Author,
-                limit=decoded.payload.limit,
-                order_bys=orders,
-                expressions=[decoded_criteria_expression, decoded_bookmark_expression],
-            )
-
-            assert [author.name for author in first_items] == [
-                "Reverse Cursor D",
-                "Reverse Cursor C",
-            ]
-            assert [author.name for author in next_items] == [
-                "Reverse Cursor B",
-                "Reverse Cursor A",
-            ]
-
-    def test_cursor_pagination_list_and_partitions_share_next_page(
-        self, engine: Engine
-    ):
-        """Test decoded cursors drive the same next page through list and partitions."""
-        criteria_model = Criteria[Author]
-        payload = {
-            "and": [
-                {"name": {"starts_with": "Full Cursor"}},
-                {"field": {"eq": "Robotics"}},
-            ],
-            "not": {"name": {"ends_with": "Outside"}},
-        }
-        limit = 2
-        orders = (Author["id"].asc(),)
-        criteria = criteria_model.model_validate(payload)
-
-        with Session(engine) as session:
-            authors = [
-                Author(name="Full Cursor A", field="Robotics"),
-                Author(name="Full Cursor B", field="Robotics"),
-                Author(name="Full Cursor C", field="Robotics"),
-                Author(name="Full Cursor D", field="Robotics"),
-                Author(name="Full Cursor Outside", field="Robotics"),
-                Author(name="Full Cursor Wrong Field", field="History"),
-            ]
-            session.add_all(authors)
-            session.flush()
-            for author in authors:
-                author.revalidate()
-
-            assert criteria.expression is not None
-            criteria_expression = criteria.expression
-            first_items = session.list(
-                Author,
-                limit=limit,
-                order_bys=orders,
-                expressions=[criteria_expression],
-            )
-            last_author_id = first_items[-1].id
-            assert last_author_id is not None
-            cursor = Cursor[Author].from_expression(
-                expression=criteria_expression,
-                bookmark=CursorBookmark[Author].from_expression(
-                    expression=Author["id"] > last_author_id,
-                    order_bys=orders,
-                ),
-                order_bys=orders,
-                limit=limit,
-            )
-            first_page = Page(
-                items=tuple(first_items),
-                total=session.count(Author, expressions=[criteria_expression]),
-                next_cursor=str(cursor),
-                has_more=True,
-            )
-
-            assert first_page.total == 4
-            assert first_page.next_cursor is not None
-            decoded = Cursor[Author](first_page.next_cursor)
-            assert decoded.criteria is not None
-            decoded_criteria_expression = decoded.criteria.expression
-            assert decoded_criteria_expression is not None
-            assert decoded_criteria_expression.dump() == criteria_expression.dump()
-            assert decoded.payload.limit == limit
-            assert decoded.payload.order_by == ("+id",)
-            assert decoded.bookmark.criteria
-            decoded_bookmark_expression = decoded.bookmark.criteria.expression
-            assert decoded_bookmark_expression is not None
-            next_list_items = session.list(
-                Author,
-                limit=decoded.payload.limit,
-                order_bys=orders,
-                expressions=[decoded_criteria_expression, decoded_bookmark_expression],
-            )
-            next_partition_items = [
-                item
-                for partition in session.partitions(
-                    Author,
-                    size=1,
-                    limit=decoded.payload.limit,
-                    order_bys=orders,
-                    expressions=[
-                        decoded_criteria_expression,
-                        decoded_bookmark_expression,
-                    ],
+            second_page_items = tuple(second_items[: decoded.limit])
+            second_bookmark = (
+                Cursor[Author].bookmark_from_item(
+                    second_page_items[-1], decoded.order_by.orders
                 )
-                for item in partition
+                if second_page_items
+                else decoded.bookmark.expression
+            )
+            second_cursor = Cursor[Author].from_expressions(
+                expressions=decoded.criteria.expressions,
+                bookmark=second_bookmark,
+                order_bys=decoded.order_by.orders,
+                limit=decoded.limit,
+            )
+            second_page = Page(
+                items=second_page_items,
+                total=4,
+                next_cursor=str(second_cursor),
+                has_more=len(second_items) > limit,
+            )
+
+            assert [author.name for author in first_page_items] == [
+                "Descending Manual Cursor D",
+                "Descending Manual Cursor C",
+            ]
+            assert decoded.order_by == ("-name",)
+            assert decoded.bookmark.model_dump(
+                mode="json", by_alias=True, exclude_none=True
+            ) == {"name": {"lt": "Descending Manual Cursor C"}}
+            assert second_page.has_more is False
+            assert second_page.next_cursor is not None
+            assert [author.name for author in second_page] == [
+                "Descending Manual Cursor B",
+                "Descending Manual Cursor A",
             ]
 
-            assert [author.name for author in first_page] == [
-                "Full Cursor A",
-                "Full Cursor B",
-            ]
-            assert [author.name for author in next_list_items] == [
-                "Full Cursor C",
-                "Full Cursor D",
-            ]
-            assert [author.name for author in next_partition_items] == [
-                "Full Cursor C",
-                "Full Cursor D",
-            ]
-
-    def test_cursor_pagination_with_complex_criteria_and_relationship_filters(
+    def test_cursor_pagination_with_empty_result_has_empty_bookmark(
         self, engine: Engine
     ):
-        """Test cursor payloads with complex criteria and relationship filters."""
-        criteria_model = Criteria[Book]
-        payload = {
-            "and": [
-                {"title": {"starts_with": "Rel Cursor"}},
-                {"year": {"ge": 2020}},
-            ],
-            "or": [
-                {"title": {"contains": "Match"}},
-                {"title": {"contains": "Next"}},
-            ],
-            "not": {"title": {"contains": "Skip"}},
-        }
-        limit = 1
-        orders = (Book["id"].asc(),)
-        criteria = criteria_model.model_validate(payload)
+        criteria = Criteria[Author].model_validate(
+            {"name": {"starts_with": "Empty Manual Cursor"}}
+        )
+        limit = 2
+        orders = (Author["id"].desc(),)
 
         with Session(engine) as session:
-            publisher = Publisher(name="Rel Cursor Publisher", country="USA")
-            matching_author = Author(name="Rel Cursor Author", field="Astrophysics")
-            other_author = Author(name="Rel Cursor Other Author", field="History")
-            category = Category(name="Rel Cursor Category", description="Pagination")
-            other_category = Category(
-                name="Rel Cursor Other Category", description="Pagination"
-            )
-
-            first_book = Book(title="Rel Cursor Match A", year=2024)
-            first_book.author.value = matching_author
-            first_book.publisher.value = publisher
-            first_book.detail.value = BookDetail(
-                isbn="978-8888830001",
-                pages=310,
-                abstract="first cursor match",
-            )
-            first_book.categories.append(category)
-
-            second_book = Book(title="Rel Cursor Next B", year=2025)
-            second_book.author.value = matching_author
-            second_book.publisher.value = publisher
-            second_book.detail.value = BookDetail(
-                isbn="978-8888830002",
-                pages=420,
-                abstract="second cursor match",
-            )
-            second_book.categories.append(category)
-
-            wrong_author_book = Book(title="Rel Cursor Match Wrong Author", year=2024)
-            wrong_author_book.author.value = other_author
-            wrong_author_book.publisher.value = publisher
-            wrong_author_book.detail.value = BookDetail(
-                isbn="978-8888830003",
-                pages=510,
-                abstract="wrong author",
-            )
-            wrong_author_book.categories.append(category)
-
-            wrong_category_book = Book(
-                title="Rel Cursor Match Wrong Category", year=2024
-            )
-            wrong_category_book.author.value = matching_author
-            wrong_category_book.publisher.value = publisher
-            wrong_category_book.detail.value = BookDetail(
-                isbn="978-8888830004",
-                pages=610,
-                abstract="wrong category",
-            )
-            wrong_category_book.categories.append(other_category)
-
-            skipped_book = Book(title="Rel Cursor Skip Match", year=2024)
-            skipped_book.author.value = matching_author
-            skipped_book.publisher.value = publisher
-            skipped_book.detail.value = BookDetail(
-                isbn="978-8888830005",
-                pages=710,
-                abstract="skipped by not criteria",
-            )
-            skipped_book.categories.append(category)
-
-            short_book = Book(title="Rel Cursor Match Too Short", year=2024)
-            short_book.author.value = matching_author
-            short_book.publisher.value = publisher
-            short_book.detail.value = BookDetail(
-                isbn="978-8888830006",
-                pages=120,
-                abstract="too short",
-            )
-            short_book.categories.append(category)
-
-            session.add_all(
-                [
-                    first_book,
-                    second_book,
-                    wrong_author_book,
-                    wrong_category_book,
-                    skipped_book,
-                    short_book,
-                ]
-            )
-            session.flush()
-            first_book.revalidate()
-            second_book.revalidate()
-
-            assert criteria.expression is not None
-            criteria_expression = criteria.expression
-            relationship_expression = (
-                Book["author"].has(Author["field"] == "Astrophysics")
-                & Book["categories"].any(Category["name"] == "Rel Cursor Category")
-                & Book["detail"].has(BookDetail["pages"] >= 300)
-            )
-            expressions = [criteria_expression, relationship_expression]
-            total = session.count(Book, expressions=expressions)
+            total = session.count(Author, expressions=criteria.expressions)
             first_items = session.list(
-                Book,
+                Author,
+                limit=limit + 1,
+                order_bys=orders,
+                expressions=criteria.expressions,
+            )
+            first_page_items = tuple(first_items[:limit])
+            bookmark = (
+                Cursor[Author].bookmark_from_item(first_page_items[-1], orders)
+                if first_page_items
+                else None
+            )
+            cursor = Cursor[Author].from_expressions(
+                expressions=criteria.expressions,
+                bookmark=bookmark,
+                order_bys=orders,
                 limit=limit,
-                order_bys=orders,
-                expressions=expressions,
             )
-            last_book_id = first_items[-1].id
-            assert last_book_id is not None
-            cursor = Cursor[Book].from_expression(
-                expression=criteria_expression,
-                bookmark=CursorBookmark[Book].from_expression(
-                    expression=Book["id"] > last_book_id,
-                    order_bys=orders,
-                ),
-                order_bys=orders,
-                limit=limit,
-            )
-            decoded = Cursor[Book](str(cursor))
-            assert decoded.criteria is not None
-            decoded_criteria_expression = decoded.criteria.expression
-            assert decoded_criteria_expression is not None
-            assert decoded.bookmark.criteria
-            decoded_bookmark_expression = decoded.bookmark.criteria.expression
-            assert decoded_bookmark_expression is not None
-            next_expressions = [
-                decoded_criteria_expression,
-                decoded_bookmark_expression,
-                relationship_expression,
-            ]
-            next_list_items = session.list(
-                Book,
-                limit=decoded.payload.limit,
-                order_bys=orders,
-                expressions=next_expressions,
-            )
-            next_page = Page(
-                items=tuple(next_list_items),
+            page = Page(
+                items=first_page_items,
                 total=total,
                 next_cursor=str(cursor),
-                has_more=total > len(first_items) + len(next_list_items),
+                has_more=len(first_items) > limit,
             )
-            next_partition_items = [
-                item
-                for partition in session.partitions(
-                    Book,
-                    size=1,
-                    limit=decoded.payload.limit,
-                    order_bys=orders,
-                    expressions=next_expressions,
-                )
-                for item in partition
-            ]
 
-            assert total == 2
-            assert next_page.total == 2
-            assert next_page.has_more is False
-            assert decoded.criteria is not None
-            assert decoded.criteria.expression is not None
-            assert decoded.criteria.expression.dump() == criteria_expression.dump()
-            assert decoded.payload.limit == limit
-            assert decoded.payload.order_by == ("+id",)
-            assert [book.title for book in first_items] == ["Rel Cursor Match A"]
-            assert [book.title for book in next_page] == ["Rel Cursor Next B"]
-            assert [book.title for book in next_partition_items] == [
-                "Rel Cursor Next B"
-            ]
+            decoded = Cursor[Author](page.next_cursor)
+
+            assert page.items == ()
+            assert page.total == 0
+            assert page.has_more is False
+            assert decoded.bookmark.expression is None
+            assert (
+                decoded.bookmark.model_dump(
+                    mode="json", by_alias=True, exclude_none=True
+                )
+                == {}
+            )

--- a/tests/sqlalchemy/sync/test_session.py
+++ b/tests/sqlalchemy/sync/test_session.py
@@ -808,10 +808,8 @@ class TestSessionHelpers:
 
             assert result.author.value.name == "Native Loader Author"
 
-    def test_list_with_json_criteria_expression_and_compiler_chain(
-        self, engine: Engine
-    ):
-        """Test JSON criteria values can drive arcanus and SQLAlchemy expressions."""
+    def test_list_with_json_criteria_expression(self, engine: Engine):
+        """Test JSON criteria values can drive Session list expressions."""
         criteria_model = Criteria[Author]
         payload = {
             "name": {"starts_with": "Criteria Chain"},
@@ -839,38 +837,16 @@ class TestSessionHelpers:
                 mode="json", by_alias=True, exclude_none=True
             ) == criteria.model_dump(mode="json", by_alias=True, exclude_none=True)
 
-            assert criteria.expression is not None
-            criteria_expression = criteria.expression
-            compiled_expression = criteria_expression(
-                sqlalchemy_materia.expression_compiler
-            )
-            compiled_order_bys = tuple(
-                order_by(sqlalchemy_materia.expression_compiler) for order_by in orders
-            )
-
-            manual_results = (
-                session.execute(
-                    select(Author)
-                    .where(compiled_expression)
-                    .order_by(*compiled_order_bys)
-                    .limit(limit)
-                )
-                .scalars()
-                .all()
-            )
             list_results = session.list(
                 Author,
-                expressions=[criteria_expression],
+                expressions=criteria.expressions,
                 order_bys=orders,
                 limit=limit,
             )
 
-            assert [author.name for author in manual_results] == [
+            assert [author.name for author in list_results] == [
                 "Criteria Chain C",
                 "Criteria Chain B",
-            ]
-            assert [author.name for author in list_results] == [
-                author.name for author in manual_results
             ]
 
     def test_list_with_text_range_criteria(self, engine: Engine):
@@ -895,36 +871,15 @@ class TestSessionHelpers:
             session.flush()
 
             criteria = criteria_model.model_validate(payload)
-            assert criteria.expression is not None
-            criteria_expression = criteria.expression
-            compiled_expression = criteria_expression(
-                sqlalchemy_materia.expression_compiler
-            )
-            compiled_order_bys = tuple(
-                order_by(sqlalchemy_materia.expression_compiler) for order_by in orders
-            )
-
-            manual_results = (
-                session.execute(
-                    select(Author)
-                    .where(compiled_expression)
-                    .order_by(*compiled_order_bys)
-                )
-                .scalars()
-                .all()
-            )
             list_results = session.list(
                 Author,
-                expressions=[criteria_expression],
+                expressions=criteria.expressions,
                 order_bys=orders,
             )
 
-            assert [author.name for author in manual_results] == [
+            assert [author.name for author in list_results] == [
                 "Text Range C",
                 "Text Range G",
-            ]
-            assert [author.name for author in list_results] == [
-                author.name for author in manual_results
             ]
 
     def test_partitions_yields_chunks(self, engine: Engine):
@@ -1032,7 +987,7 @@ class TestSessionHelpers:
             session.flush()
 
             criteria = criteria_model.model_validate_json(json.dumps(payload))
-            assert criteria.expression is not None
+            assert criteria.expressions
 
             all_results = []
             for partition in session.partitions(
@@ -1040,7 +995,7 @@ class TestSessionHelpers:
                 size=2,
                 limit=limit,
                 order_bys=orders,
-                expressions=[criteria.expression],
+                expressions=criteria.expressions,
             ):
                 all_results.extend(partition)
 

--- a/tests/test_criteria.py
+++ b/tests/test_criteria.py
@@ -16,7 +16,8 @@ from arcanus import (
 )
 from arcanus.criteria import (
     BaseCriteria,
-    CursorBookmark,
+    BookmarkCriteria,
+    ExactCriteria,
     Ordering,
     TextCriteria,
 )
@@ -49,15 +50,12 @@ def test_nested_criteria_accepts_one_layer_relationship_criteria():
         "books": {"title": {"eq": "Notes"}},
     }
     with sqlalchemy_materia:
-        expression = criteria.expression
+        expressions = criteria.expressions
 
-    assert expression is not None
-    assert expression.dump() == {
-        "and": [
-            {"name": {"eq": "Ada"}},
-            {"books": {"title": {"eq": "Notes"}}},
-        ]
-    }
+    assert tuple(expression.dump() for expression in expressions) == (
+        {"name": {"eq": "Ada"}},
+        {"books": {"title": {"eq": "Notes"}}},
+    )
 
 
 def test_nested_criteria_bool_branches_accept_one_layer_relationships():
@@ -79,15 +77,12 @@ def test_nested_criteria_bool_branches_accept_one_layer_relationships():
         ]
     }
     with sqlalchemy_materia:
-        expression = criteria.expression
+        expressions = criteria.expressions
 
-    assert expression is not None
-    assert expression.dump() == {
-        "and": [
-            {"name": {"eq": "Ada"}},
-            {"books": {"title": {"eq": "Notes"}}},
-        ]
-    }
+    assert tuple(expression.dump() for expression in expressions) == (
+        {"name": {"eq": "Ada"}},
+        {"books": {"title": {"eq": "Notes"}}},
+    )
 
 
 def test_nested_criteria_bool_branches_keep_deeper_logic_scalar():
@@ -109,12 +104,10 @@ def test_nested_criteria_bool_branches_keep_deeper_logic_scalar():
 
 def test_nested_cursor_round_trips_relationship_criteria():
     with sqlalchemy_materia:
-        bookmark = CursorBookmark[Author].from_expression(
-            order_bys=(Author["id"].desc(),)
-        )
-        cursor = NestedCursor[Author].from_expression(
-            expression=Author["books"].any(Book["title"] == "Notes"),
-            bookmark=bookmark,
+        cursor = NestedCursor[Author].from_expressions(
+            expressions=(Author["books"].any(Book["title"] == "Notes"),),
+            bookmark=Author["id"] < 123,
+            order_bys=(Author["id"].desc(),),
             limit=10,
         )
         restored = NestedCursor[Author](str(cursor))
@@ -123,18 +116,18 @@ def test_nested_cursor_round_trips_relationship_criteria():
     dumped = restored.criteria.model_dump(mode="json", by_alias=True, exclude_none=True)
     assert dumped == {"books": {"title": {"eq": "Notes"}}}
     assert restored.limit == 10
-    assert restored.bookmark.order_by == ("-id",)
+    assert restored.order_by == ("-id",)
 
 
 def test_nested_cursor_round_trips_scalar_and_relationship_criteria():
     with sqlalchemy_materia:
-        bookmark = CursorBookmark[Author].from_expression(
-            order_bys=(Author["id"].desc(),)
-        )
-        cursor = NestedCursor[Author].from_expression(
-            expression=(Author["name"] == "Ada")
-            & Author["books"].any(Book["title"] == "Notes"),
-            bookmark=bookmark,
+        cursor = NestedCursor[Author].from_expressions(
+            expressions=(
+                (Author["name"] == "Ada")
+                & Author["books"].any(Book["title"] == "Notes"),
+            ),
+            bookmark=Author["id"] < 123,
+            order_bys=(Author["id"].desc(),),
             limit=10,
         )
         restored = NestedCursor[Author](str(cursor))
@@ -186,7 +179,7 @@ def test_literal_fields_use_exact_value_criteria():
     criteria = criteria_model.model_validate(
         {"field": {"eq": "Physics", "in": ["Biology", "History"]}}
     )
-    field_criteria: BaseCriteria[str] | None = getattr(criteria, "field")
+    field_criteria: ExactCriteria[str] | None = getattr(criteria, "field")
 
     assert field_criteria is not None
     assert field_criteria.eq == "Physics"
@@ -213,16 +206,13 @@ def test_text_criteria_accepts_range_operators():
     assert name_criteria.gt == "Ada"
     assert name_criteria.ge == "Ada"
     with sqlalchemy_materia:
-        expression = criteria.expression
-    assert expression is not None
-    assert expression.dump() == {
-        "and": [
-            {"name": {"lt": "Grace"}},
-            {"name": {"le": "Grace"}},
-            {"name": {"gt": "Ada"}},
-            {"name": {"ge": "Ada"}},
-        ]
-    }
+        expressions = criteria.expressions
+    assert tuple(expression.dump() for expression in expressions) == (
+        {"name": {"lt": "Grace"}},
+        {"name": {"le": "Grace"}},
+        {"name": {"gt": "Ada"}},
+        {"name": {"ge": "Ada"}},
+    )
 
 
 def test_criteria_validation_accepts_nested_logical_fields():
@@ -268,7 +258,7 @@ def test_expression_dump_round_trips_through_criteria_json():
     assert restored.model_dump(mode="json", by_alias=True, exclude_none=True) == payload
 
 
-def test_criteria_expression_property_returns_arcanus_expression():
+def test_criteria_expressions_property_returns_arcanus_expressions():
     criteria_model = Criteria[Author]
     criteria = criteria_model.model_validate(
         {
@@ -279,17 +269,14 @@ def test_criteria_expression_property_returns_arcanus_expression():
     )
 
     with sqlalchemy_materia:
-        expression = criteria.expression
+        expressions = criteria.expressions
 
-    assert expression is not None
-    assert expression is criteria.expression
-    assert expression.dump() == {
-        "and": [
-            {"name": {"contains": "Ada"}},
-            {"field": {"eq": "Physics"}},
-            {"not": {"id": {"in": [1, 2]}}},
-        ]
-    }
+    assert expressions is criteria.expressions
+    assert tuple(expression.dump() for expression in expressions) == (
+        {"name": {"contains": "Ada"}},
+        {"field": {"eq": "Physics"}},
+        {"not": {"id": {"in": [1, 2]}}},
+    )
 
 
 def test_criteria_json_schema_uses_recursive_objects_for_logical_fields():
@@ -324,12 +311,9 @@ def test_cursor_payload_bookmark_is_separate_from_paged_criteria():
         }
     )
     with sqlalchemy_materia:
-        cursor = Cursor[Author].from_expression(
-            expression=criteria.expression,
-            bookmark=CursorBookmark[Author].from_expression(
-                expression=Author["id"] > 123,
-                order_bys=(Author["id"].asc(),),
-            ),
+        cursor = Cursor[Author].from_expressions(
+            expressions=criteria.expressions,
+            bookmark=Author["id"] > 123,
             order_bys=(Author["id"].asc(),),
             limit=100,
         )
@@ -337,13 +321,13 @@ def test_cursor_payload_bookmark_is_separate_from_paged_criteria():
 
     with sqlalchemy_materia:
         assert decoded.criteria is not None
-        assert decoded.bookmark.criteria is not None
-        criteria_expression = decoded.criteria.expression
-        bookmark_expression = decoded.bookmark.criteria.expression
+        criteria_expressions = decoded.criteria.expressions
+        bookmark_expression = decoded.bookmark.expression
 
-    assert criteria_expression is not None
+    assert tuple(expression.dump() for expression in criteria_expressions) == (
+        {"name": {"starts_with": "Ada"}},
+    )
     assert bookmark_expression is not None
-    assert criteria_expression.dump() == {"name": {"starts_with": "Ada"}}
     assert bookmark_expression.dump() == {"id": {"gt": 123}}
 
 
@@ -355,8 +339,9 @@ def test_upper_criteria_handles_scalar_field_expression_translation():
     assert name_criteria is not None
     assert name_criteria.contains == "Ada"
     with sqlalchemy_materia:
-        assert criteria.expression is not None
-        assert criteria.expression.dump() == {"name": {"contains": "Ada"}}
+        expressions = criteria.expressions
+        assert expressions
+        assert expressions[0].dump() == {"name": {"contains": "Ada"}}
 
 
 def test_cursor_from_expression_round_trips_payload_and_token():
@@ -368,15 +353,11 @@ def test_cursor_from_expression_round_trips_payload_and_token():
     )
 
     with sqlalchemy_materia:
-        cursor = Cursor[Author].from_expression(
-            expression=criteria.expression,
-            bookmark=CursorBookmark[Author].from_expression(
-                expression=Author["id"] > 42,
-                order_bys=(Author["name"].asc(), Author["id"].desc()),
-            ),
+        cursor = Cursor[Author].from_expressions(
+            expressions=criteria.expressions,
+            bookmark=Author["id"] > 42,
             order_bys=(Author["name"].asc(), Author["id"].desc()),
             limit=20,
-            offset=10,
         )
     token = str(cursor)
     decoded = Cursor[Author].model_validate(token)
@@ -393,28 +374,22 @@ def test_cursor_from_expression_round_trips_payload_and_token():
         "name": {"starts_with": "Ada"},
     }
     assert decoded.payload.limit == 20
-    assert decoded.payload.offset == 10
     assert decoded.payload.order_by == ("+name", "-id")
-    assert decoded.bookmark.criteria is not None
-    assert decoded.bookmark.criteria.model_dump(
+    assert decoded.bookmark is not None
+    assert decoded.bookmark.model_dump(
         mode="json", by_alias=True, exclude_none=True
     ) == {"id": {"gt": 42}}
-    assert decoded.bookmark.order_by == ("+name", "-id")
 
 
 def test_cursor_from_expression_builds_criteria_from_expression_dump():
     with sqlalchemy_materia:
         expression = Author["name"].starts_with("Ada") & (Author["field"] == "Physics")
         bookmark = Author["id"] > 42
-        cursor = Cursor[Author].from_expression(
-            expression=expression,
-            bookmark=CursorBookmark[Author].from_expression(
-                expression=bookmark,
-                order_bys=(Author["name"].asc(), Author["id"].desc()),
-            ),
+        cursor = Cursor[Author].from_expressions(
+            expressions=(expression,),
+            bookmark=bookmark,
             order_bys=(Author["name"].asc(), Author["id"].desc()),
             limit=20,
-            offset=10,
         )
 
     decoded = Cursor[Author](str(cursor))
@@ -429,13 +404,11 @@ def test_cursor_from_expression_builds_criteria_from_expression_dump():
         ],
     }
     assert decoded.payload.limit == 20
-    assert decoded.payload.offset == 10
     assert decoded.payload.order_by == ("+name", "-id")
-    assert decoded.bookmark.criteria is not None
-    assert decoded.bookmark.criteria.model_dump(
+    assert decoded.bookmark is not None
+    assert decoded.bookmark.model_dump(
         mode="json", by_alias=True, exclude_none=True
     ) == {"id": {"gt": 42}}
-    assert decoded.bookmark.order_by == ("+name", "-id")
 
 
 def test_ordering_validates_model_scalar_fields_as_root_model():
@@ -456,58 +429,85 @@ def test_ordering_validates_model_scalar_fields_as_root_model():
         order_by_model.model_validate(["-books"])
 
 
-def test_cursor_bookmark_order_by_reuses_order_by_model():
-    bookmark_model = CursorBookmark[Author]
+def test_bookmark_criteria_uses_implicit_or_branches():
+    bookmark_model = BookmarkCriteria[Author]
 
     bookmark = bookmark_model.model_validate(
         {
-            "criteria": {"id": {"gt": 42}},
-            "order_by": ["+name", "-id"],
+            "or": [
+                {"name": {"gt": "Ada"}},
+                {"and": [{"name": {"eq": "Ada"}}, {"id": {"lt": 42}}]},
+            ]
         }
     )
 
-    assert bookmark.criteria is not None
-    assert bookmark.criteria.model_dump(
-        mode="json", by_alias=True, exclude_none=True
-    ) == {"id": {"gt": 42}}
-    assert bookmark.order_by == ("+name", "-id")
-
-    with pytest.raises(ValidationError):
-        bookmark_model.model_validate(
-            {
-                "criteria": {"id": {"gt": 42}},
-                "order_by": ["books"],
-            }
-        )
-
-    with pytest.raises(ValidationError):
-        bookmark_model.model_validate(
-            {
-                "criteria": {"id": {"gt": 42}},
-                "order_by": ["-books"],
-            }
-        )
-
-
-def test_cursor_bookmark_can_be_order_only():
+    assert bookmark.model_dump(mode="json", by_alias=True, exclude_none=True) == {
+        "or": [
+            {"name": {"gt": "Ada"}},
+            {"and": [{"name": {"eq": "Ada"}}, {"id": {"lt": 42}}]},
+        ]
+    }
     with sqlalchemy_materia:
-        bookmark = CursorBookmark[Author].from_expression(
-            order_bys=(Author["id"].desc(),)
+        expression = bookmark.expression
+        assert expression is not None
+        assert expression.dump() == {
+            "or": [
+                {"name": {"gt": "Ada"}},
+                {
+                    "and": [
+                        {"name": {"eq": "Ada"}},
+                        {"id": {"lt": 42}},
+                    ]
+                },
+            ]
+        }
+
+    with pytest.raises(ValidationError):
+        bookmark_model.model_validate({"name": {"starts_with": "Ada"}})
+
+    with pytest.raises(ValidationError):
+        bookmark_model.model_validate({"id": {"in": [42]}})
+
+    with pytest.raises(ValidationError):
+        bookmark_model.model_validate({"id": {"le": 42}})
+
+    with pytest.raises(ValidationError):
+        bookmark_model.model_validate({"id": {"ge": 42}})
+
+
+def test_cursor_requires_order_and_bookmark():
+    with sqlalchemy_materia:
+        cursor = Cursor[Author].from_expressions(
+            bookmark=Author["id"] < 123,
+            order_bys=(Author["id"].desc(),),
         )
 
-    assert bookmark.criteria is None
-    assert bookmark.order_by == ("-id",)
+    assert cursor.bookmark.model_dump(
+        mode="json", by_alias=True, exclude_none=True
+    ) == {"id": {"lt": 123}}
+    assert cursor.order_by == ("-id",)
+
+    with (
+        sqlalchemy_materia,
+        pytest.raises(ValidationError, match="Cursor requires order_by"),
+    ):
+        Cursor[Author].from_expressions(bookmark=Author["id"] > 0, order_bys=())
+
+    with sqlalchemy_materia:
+        cursor = Cursor[Author].from_expressions(order_bys=(Author["id"].desc(),))
+
+    assert cursor.bookmark.expression is None
+    assert (
+        cursor.bookmark.model_dump(mode="json", by_alias=True, exclude_none=True) == {}
+    )
 
 
 def test_cursor_validation_rejects_invalid_token_and_entity():
     criteria = Criteria[Author].model_validate({"name": {"eq": "Ada"}})
     with sqlalchemy_materia:
-        cursor = Cursor[Author].from_expression(
-            bookmark=CursorBookmark[Author].from_expression(
-                expression=Author["id"] > 0,
-                order_bys=(Author["id"].asc(),),
-            ),
-            expression=criteria.expression,
+        cursor = Cursor[Author].from_expressions(
+            expressions=criteria.expressions,
+            bookmark=Author["id"] > 0,
             order_bys=(Author["id"].asc(),),
             limit=100,
         )
@@ -526,7 +526,7 @@ def test_cursor_validation_rejects_invalid_token_and_entity():
         Cursor[Author].model_validate(bad_entity_token)
 
     bad_bookmark_payload = cursor.payload.model_dump(mode="json", by_alias=True)
-    bad_bookmark_payload["bookmark"]["order_by"] = ["-books"]
+    bad_bookmark_payload["bookmark"] = {"name": {"gt": "Ada"}}
     bad_bookmark_token = (
         base64.urlsafe_b64encode(json.dumps(bad_bookmark_payload).encode())
         .decode()
@@ -539,22 +539,16 @@ def test_cursor_validation_rejects_invalid_token_and_entity():
 def test_cursor_validation_hides_invalid_payload_as_cursor_error():
     criteria = Criteria[Author].model_validate({"name": {"eq": "Ada"}})
     with sqlalchemy_materia:
-        cursor = Cursor[Author].from_expression(
-            bookmark=CursorBookmark[Author].from_expression(
-                expression=Author["id"] > 0,
-                order_bys=(Author["id"].asc(),),
-            ),
-            expression=criteria.expression,
+        cursor = Cursor[Author].from_expressions(
+            expressions=criteria.expressions,
+            bookmark=Author["id"] > 0,
             order_bys=(Author["id"].asc(),),
             limit=100,
         )
         token = str(
-            Cursor[Author].from_expression(
-                bookmark=CursorBookmark[Author].from_expression(
-                    expression=Author["id"] > 0,
-                    order_bys=(Author["id"].asc(),),
-                ),
-                expression=criteria.expression,
+            Cursor[Author].from_expressions(
+                expressions=criteria.expressions,
+                bookmark=Author["id"] > 0,
                 order_bys=(Author["id"].asc(),),
                 limit=100,
             )
@@ -570,15 +564,12 @@ def test_cursor_validation_hides_invalid_payload_as_cursor_error():
         Cursor[Author].model_validate(invalid_token)
 
 
-def test_cursor_validation_rejects_bad_version_and_missing_bookmark():
+def test_cursor_validation_rejects_bad_version_and_missing_required_payload_fields():
     criteria = Criteria[Author].model_validate({"name": {"eq": "Ada"}})
     with sqlalchemy_materia:
-        cursor = Cursor[Author].from_expression(
-            bookmark=CursorBookmark[Author].from_expression(
-                expression=Author["id"] > 0,
-                order_bys=(Author["id"].asc(),),
-            ),
-            expression=criteria.expression,
+        cursor = Cursor[Author].from_expressions(
+            expressions=criteria.expressions,
+            bookmark=Author["id"] > 0,
             order_bys=(Author["id"].asc(),),
             limit=100,
         )
@@ -590,6 +581,16 @@ def test_cursor_validation_rejects_bad_version_and_missing_bookmark():
     )
     with pytest.raises(ValidationError, match="Invalid cursor token"):
         Cursor[Author](bad_version_token)
+
+    missing_order_payload = cursor.payload.model_dump(mode="json", by_alias=True)
+    del missing_order_payload["order_by"]
+    missing_order_token = (
+        base64.urlsafe_b64encode(json.dumps(missing_order_payload).encode())
+        .decode()
+        .rstrip("=")
+    )
+    with pytest.raises(ValidationError, match="Invalid cursor token"):
+        Cursor[Author](missing_order_token)
 
     del payload["bookmark"]
     payload["version"] = 1
@@ -627,13 +628,13 @@ def test_page_unwraps_items_like_a_tuple():
 
 
 def test_empty_page_is_false_and_has_no_cursor():
-    page = Page[str](items=(), next_cursor=None, has_more=False)
+    page = Page[str](items=(), next_cursor="next", has_more=False)
 
     assert not page
     assert page.total == 0
     assert len(page) == 0
     assert list(page) == []
-    assert page.next_cursor is None
+    assert page.next_cursor == "next"
     assert page.has_more is False
 
 


### PR DESCRIPTION
## Summary

- Simplifies cursor pagination criteria so cursors carry explicit order-by and a single bookmark expression.
- Moves bookmark creation to return expressions directly and updates criteria exports accordingly.
- Reworks pagination tests around the new cursor/bookmark behavior for sync and async SQLAlchemy flows.

## Validation

- `uv run ruff check .` passed.
- `uv run pytest` passed: 1029 passed, 1 skipped.
- `uv run pyright arcanus/__init__.py arcanus/criteria.py tests/sqlalchemy/async/test_async_operations.py tests/sqlalchemy/async/test_pagination.py tests/sqlalchemy/sync/test_pagination.py tests/sqlalchemy/sync/test_session.py tests/test_criteria.py` passed.
- Full `uv run pyright` still reports existing project-wide type issues outside this patch, mostly in association/sqlalchemy/benchmark files.