### PR TITLE
feat: first-class computed fields backed by provider expressions

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -16,10 +16,8 @@ jobs:
         name: Validate Conventional Commit title
         runs-on: ubuntu-latest
         steps:
-            # Advisory only: the squash-merge subject is the PR title, so release-please reads
-            # it for the version bump + changelog. A non-conventional title still merges — it
-            # just won't be picked up by release-please — so this warns but never blocks.
+            # The PR title becomes the squash-merge commit subject that release-please reads,
+            # so it must be a valid Conventional Commit.
             - uses: amannn/action-semantic-pull-request@v6
-              continue-on-error: true
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,5 @@ so they must follow [Conventional Commits](https://www.conventionalcommits.org/)
 ### Squash merges use the PR title
 
 This repo merges PRs by **squash**, so the squashed commit subject is the **PR title**.
-Prefer a valid Conventional Commit (e.g. `feat: add cursor pagination`) — release-please
-only bumps the version and writes a changelog entry for titles it can parse. The
-[`PR Title` check](.github/workflows/pr-title-lint.yml) posts a warning on a non-conventional
-title but **does not block the merge**, so such a PR simply won't appear in the changelog.
+Make the PR title a valid Conventional Commit (e.g. `feat: add cursor pagination`). The
+[`PR Title` check](.github/workflows/pr-title-lint.yml) enforces this on every PR.

--- a/arcanus/__init__.py
+++ b/arcanus/__init__.py
@@ -18,6 +18,7 @@ from arcanus.base import (
     BaseTransmuter,
     Transmuter,
     TransmuterType,
+    provided,
 )
 from arcanus.criteria import (
     BookmarkCriteria,
@@ -37,6 +38,7 @@ __all__ = [
     "BaseTransmuter",
     "Transmuter",
     "TransmuterType",
+    "provided",
     "Criteria",
     "BookmarkCriteria",
     "Cursor",

--- a/arcanus/association.py
+++ b/arcanus/association.py
@@ -216,6 +216,23 @@ class Association(Generic[A]):
         """Bless the value into the generic type."""
         return self.__validator__.validate_python(value)
 
+    @property
+    def loaded(self) -> bool:
+        """Whether reading this association cannot fire a provider load."""
+        if self.__loaded__ or self.__instance__ is None:
+            return True
+        return active_materia.get().association_loaded(self)
+
+    def peek(self) -> A | None:
+        """Return the association value without ever firing a load.
+
+        Resolves normally when the value is already loaded (or loading is
+        free for the active materia); returns ``None`` when resolving would
+        require provider IO. Safe to call from synchronous code such as
+        pydantic computed fields, serializers, and validators.
+        """
+        return self._load() if self.loaded else None
+
 
 class Relation(Association[Optional_T]):
     # new item and loaded item are shared the __payloads__ here

--- a/arcanus/base.py
+++ b/arcanus/base.py
@@ -188,7 +188,10 @@ class Transmuter(metaclass=TransmuterTypingMetaclass):
         if (
             isinstance(name, str)
             and isinstance(cls, TransmuterMetaclass)
-            and name in cls.__pydantic_fields__
+            and (
+                name in cls.__pydantic_fields__
+                or name in getattr(cls, "__pydantic_computed_fields__", {})
+            )
         ):
             return cls._column(name)
         return BaseModel.__class_getitem__.__func__(cls, name)
@@ -542,7 +545,16 @@ class TransmuterMetaclass(TransmuterTypingMetaclass, ModelMetaclass):
             ) from e
 
     def _column(self, name: str) -> Column[Any]:
-        if info := self.__pydantic_fields__.get(name):
+        info = self.__pydantic_fields__.get(name)
+        if info is None and (
+            computed := getattr(self, "__pydantic_computed_fields__", {}).get(name)
+        ):
+            # Computed fields carry no FieldInfo; synthesize one so the Column
+            # keeps the same metadata shape as regular fields. The provider is
+            # expected to expose a same-named expression-capable attribute
+            # (e.g. a SQLAlchemy hybrid_property) for filtering/ordering.
+            info = FieldInfo(annotation=computed.return_type, alias=computed.alias)
+        if info:
             if provider := self.__transmuter_provider__:
                 try:
                     used_name = info.alias or name
@@ -580,7 +592,10 @@ class TransmuterMetaclass(TransmuterTypingMetaclass, ModelMetaclass):
     def __getitem__(self, name: object) -> Any: ...
 
     def __getitem__(self, name: object) -> Column[Any] | Any:
-        if isinstance(name, str) and name in self.__pydantic_fields__:
+        if isinstance(name, str) and (
+            name in self.__pydantic_fields__
+            or name in getattr(self, "__pydantic_computed_fields__", {})
+        ):
             return self._column(name)
         return self.__class_getitem__(name)
 

--- a/arcanus/base.py
+++ b/arcanus/base.py
@@ -131,6 +131,51 @@ class Identity:
     """Marker class for identity fields that could not be set in creation and immutable."""
 
 
+PROVIDED_FIELD_MARK = "__transmuter_provided_field__"
+
+F = TypeVar("F")
+
+
+def provided(target: F) -> F:
+    """Mark a computed field as backed by a same-named provider attribute.
+
+    Only marked computed fields join the expression layer — ``Schema[name]``
+    resolution, criteria query params, ordering, and cursor bookmarks — by
+    compiling through the provider's attribute (e.g. a SQLAlchemy
+    ``hybrid_property``). Unmarked computed fields stay serialization-only.
+
+    Stacks anywhere around pydantic's ``computed_field``/``property`` pair::
+
+        @computed_field
+        @provided
+        @property
+        def title(self) -> str | None: ...
+
+    The mark lives on the getter function, so ``@title.setter`` rebinds
+    (which reuse the getter) keep it.
+    """
+    wrapped = getattr(target, "wrapped", target)  # pydantic descriptor proxy
+    getter = (
+        getattr(wrapped, "fget", None)  # property
+        or getattr(wrapped, "func", None)  # functools.cached_property
+        or wrapped
+    )
+    setattr(getter, PROVIDED_FIELD_MARK, True)
+    return target
+
+
+def provided_computed_fields(owner: type[Any] | Any) -> dict[str, Any]:
+    """Computed fields of *owner* marked with :func:`provided`, by name."""
+    computed_fields: dict[str, Any] = getattr(owner, "__pydantic_computed_fields__", {})
+    provided_fields: dict[str, Any] = {}
+    for name, computed in computed_fields.items():
+        prop = computed.wrapped_property
+        getter = getattr(prop, "fget", None) or getattr(prop, "func", None) or prop
+        if getattr(getter, PROVIDED_FIELD_MARK, False):
+            provided_fields[name] = computed
+    return provided_fields
+
+
 class Transmuter(metaclass=TransmuterTypingMetaclass):
     """
     A mixin base providing common transmuter instance methods.
@@ -189,11 +234,18 @@ class Transmuter(metaclass=TransmuterTypingMetaclass):
             isinstance(name, str)
             and isinstance(cls, TransmuterMetaclass)
             and (
-                name in cls.__pydantic_fields__
-                or name in getattr(cls, "__pydantic_computed_fields__", {})
+                name in cls.__pydantic_fields__ or name in provided_computed_fields(cls)
             )
         ):
             return cls._column(name)
+        if isinstance(name, str) and name in getattr(
+            cls, "__pydantic_computed_fields__", {}
+        ):
+            raise KeyError(
+                f"Computed field '{name}' of {cls.__name__} is not marked with "
+                "@provided; only provided computed fields resolve to provider "
+                "expressions."
+            )
         return BaseModel.__class_getitem__.__func__(cls, name)
 
     def __hash__(self) -> int:
@@ -546,13 +598,12 @@ class TransmuterMetaclass(TransmuterTypingMetaclass, ModelMetaclass):
 
     def _column(self, name: str) -> Column[Any]:
         info = self.__pydantic_fields__.get(name)
-        if info is None and (
-            computed := getattr(self, "__pydantic_computed_fields__", {}).get(name)
-        ):
-            # Computed fields carry no FieldInfo; synthesize one so the Column
-            # keeps the same metadata shape as regular fields. The provider is
-            # expected to expose a same-named expression-capable attribute
-            # (e.g. a SQLAlchemy hybrid_property) for filtering/ordering.
+        if info is None and (computed := provided_computed_fields(self).get(name)):
+            # @provided computed fields carry no FieldInfo; synthesize one so
+            # the Column keeps the same metadata shape as regular fields. The
+            # provider is expected to expose a same-named expression-capable
+            # attribute (e.g. a SQLAlchemy hybrid_property) for
+            # filtering/ordering.
             info = FieldInfo(annotation=computed.return_type, alias=computed.alias)
         if info:
             if provider := self.__transmuter_provider__:
@@ -593,8 +644,7 @@ class TransmuterMetaclass(TransmuterTypingMetaclass, ModelMetaclass):
 
     def __getitem__(self, name: object) -> Column[Any] | Any:
         if isinstance(name, str) and (
-            name in self.__pydantic_fields__
-            or name in getattr(self, "__pydantic_computed_fields__", {})
+            name in self.__pydantic_fields__ or name in provided_computed_fields(self)
         ):
             return self._column(name)
         return self.__class_getitem__(name)

--- a/arcanus/criteria.py
+++ b/arcanus/criteria.py
@@ -38,7 +38,7 @@ from pydantic.errors import PydanticUndefinedAnnotation, PydanticUserError
 from pydantic_core import PydanticCustomError
 
 from arcanus.association import is_association
-from arcanus.base import TransmuterType, transmuter_type
+from arcanus.base import TransmuterType, provided_computed_fields, transmuter_type
 from arcanus.expression import Column, Expression, Order, and_, or_
 
 P = TypeVar("P")
@@ -73,8 +73,12 @@ class BaseCriteria(BaseModel, Generic[T]):
     )
 
     eq: T | None = None
+    is_null: bool | None = None
 
-    criteria_operators: ClassVar[tuple[tuple[str, str], ...]] = (("eq", "eq"),)
+    criteria_operators: ClassVar[tuple[tuple[str, str], ...]] = (
+        ("eq", "eq"),
+        ("is_null", "is_null"),
+    )
 
 
 class ExactCriteria(BaseCriteria[T]):
@@ -314,20 +318,18 @@ class ScalarCriteria(ModelGeneric[P]):
     ) -> dict[str, Any]:
         """Names and value annotations of criteria-eligible attributes.
 
-        Regular scalar fields plus computed fields (keyed by return type).
-        Computed fields are included so that schemas pairing a pydantic
-        ``@computed_field`` with a provider-side expression (e.g. a SQLAlchemy
-        ``hybrid_property``) are filterable and orderable like plain columns.
+        Regular scalar fields plus ``@provided`` computed fields (keyed by
+        return type). Marking a computed field with :func:`arcanus.provided`
+        declares it is backed by a provider-side expression (e.g. a SQLAlchemy
+        ``hybrid_property``), making it filterable and orderable like a plain
+        column; unmarked computed fields stay serialization-only.
         """
         annotations = {
             name: info.annotation
             for name, info in generic_model.__pydantic_fields__.items()
             if name not in generic_model.model_associations
         }
-        computed_fields: dict[str, Any] = getattr(
-            generic_model, "__pydantic_computed_fields__", {}
-        )
-        for name, computed in computed_fields.items():
+        for name, computed in provided_computed_fields(generic_model).items():
             annotations.setdefault(name, computed.return_type)
         return annotations
 
@@ -403,10 +405,17 @@ class ScalarCriteria(ModelGeneric[P]):
         def criteria_example(
             criteria_type: type[BaseCriteria[Any]], value: CriteriaExampleValue
         ) -> CriteriaExample:
+            def attribute_example(attribute: str) -> Any:
+                if attribute in {"in_", "not_in"}:
+                    return [value]
+                if attribute == "is_null":
+                    return True
+                return value
+
             return {
-                (criteria_type.model_fields[attribute].alias or attribute): [value]
-                if attribute in {"in_", "not_in"}
-                else value
+                (criteria_type.model_fields[attribute].alias or attribute): (
+                    attribute_example(attribute)
+                )
                 for attribute, _ in criteria_type.criteria_operators
             }
 
@@ -795,6 +804,27 @@ class BookmarkCriteria(ScalarCriteria[P]):
         return expressions[0] if len(expressions) == 1 else and_(expressions)
 
 
+def _bookmark_after(
+    column: Column[CriteriaValue], value: CriteriaValue | None, descending: bool
+) -> Expression[bool] | None:
+    """Strictly-after comparison for one order key of a cursor bookmark.
+
+    Ordering is normalized to ASC NULLS LAST / DESC NULLS FIRST (the
+    PostgreSQL defaults), so:
+    - ascending, after a value: greater values, then the trailing null region;
+    - ascending, after a null: nothing at this level (deeper keys tiebreak);
+    - descending, after a value: smaller values only (nulls already passed);
+    - descending, after a null: the entire non-null region.
+    """
+    if value is None:
+        if descending:
+            return column.operate("is_null", False)
+        return None
+    if descending:
+        return column < value
+    return or_((column > value, column.operate("is_null", True)))
+
+
 def bookmark_criteria_fields(bookmark: BookmarkCriteria[Any]) -> set[str]:
     fields: set[str] = set()
     for name, value in bookmark:
@@ -985,11 +1015,19 @@ class Cursor(RootModel[str], Generic[P]):
         for order_by in order_bys:
             column = order_by.column
             value = getattr(item, column.field_name)
-            comparison = column < value if order_by.descending else column > value
-            clauses.append(
-                comparison if not equalities else and_((*equalities, comparison))
+            comparison = _bookmark_after(column, value, order_by.descending)
+            if comparison is not None:
+                clauses.append(
+                    comparison if not equalities else and_((*equalities, comparison))
+                )
+            equalities.append(
+                column.operate("is_null", True) if value is None else column == value
             )
-            equalities.append(column == value)
+        if not clauses:
+            raise PydanticCustomError(
+                "invalid_cursor",
+                "Cursor bookmark requires a non-null unique tiebreak order key",
+            )
         return clauses[0] if len(clauses) == 1 else or_(clauses)
 
     @property

--- a/arcanus/criteria.py
+++ b/arcanus/criteria.py
@@ -309,16 +309,38 @@ class ScalarCriteria(ModelGeneric[P]):
     }
 
     @classmethod
+    def __get_generic_model_value_annotations__(
+        cls, generic_model: TransmuterType
+    ) -> dict[str, Any]:
+        """Names and value annotations of criteria-eligible attributes.
+
+        Regular scalar fields plus computed fields (keyed by return type).
+        Computed fields are included so that schemas pairing a pydantic
+        ``@computed_field`` with a provider-side expression (e.g. a SQLAlchemy
+        ``hybrid_property``) are filterable and orderable like plain columns.
+        """
+        annotations = {
+            name: info.annotation
+            for name, info in generic_model.__pydantic_fields__.items()
+            if name not in generic_model.model_associations
+        }
+        computed_fields: dict[str, Any] = getattr(
+            generic_model, "__pydantic_computed_fields__", {}
+        )
+        for name, computed in computed_fields.items():
+            annotations.setdefault(name, computed.return_type)
+        return annotations
+
+    @classmethod
     def __get_generic_model_field_definitions__(
         cls, generic_model: TransmuterType
     ) -> dict[str, Any]:
         scalar_fields: dict[str, Any] = {}
 
-        for name, info in generic_model.__pydantic_fields__.items():
-            if name in generic_model.model_associations:
-                continue
+        for name, annotation in cls.__get_generic_model_value_annotations__(
+            generic_model
+        ).items():
             # Normalize scalar field annotations before mapping them to criteria types.
-            annotation = info.annotation
             origin = get_origin(annotation)
             if origin is UnionType or str(origin) == "typing.Union":
                 annotation = next(
@@ -388,10 +410,9 @@ class ScalarCriteria(ModelGeneric[P]):
                 for attribute, _ in criteria_type.criteria_operators
             }
 
-        for name, info in generic_model.__pydantic_fields__.items():
-            if name in generic_model.model_associations:
-                continue
-            annotation = info.annotation
+        for name, annotation in cls.__get_generic_model_value_annotations__(
+            generic_model
+        ).items():
             origin = get_origin(annotation)
             if origin is UnionType or str(origin) == "typing.Union":
                 annotation = next(

--- a/arcanus/expression.py
+++ b/arcanus/expression.py
@@ -51,6 +51,8 @@ class NativeExpressionCompiler(ExpressionCompiler[Any, Any]):
             return native.is_(unwrap(value))
         if operator == "is_not":
             return native.is_not(unwrap(value))
+        if operator == "is_null":
+            return native.is_(None) if unwrap(value) else native.is_not(None)
         if operator == "between":
             left, right = cast(tuple[object, object], unwrap(value))
             return native.between(left, right)

--- a/arcanus/materia/base.py
+++ b/arcanus/materia/base.py
@@ -177,6 +177,14 @@ class BaseMateria:
     async def aload_association(self, association: Association) -> Any:
         raise NotImplementedError()
 
+    def association_loaded(self, association: Association) -> bool:
+        """Whether reading *association* from its provider cannot fire a load.
+
+        Materias with lazy loading (e.g. SQLAlchemy) override this; for
+        everything else provider data is always in memory.
+        """
+        return True
+
 
 class NoOpMateria(BaseMateria):
     _instance: ClassVar[Optional[NoOpMateria]] = None

--- a/arcanus/materia/sqlalchemy/base.py
+++ b/arcanus/materia/sqlalchemy/base.py
@@ -289,3 +289,10 @@ class SqlalchemyMateria(BaseMateria):
 
     def aload_association(self, association: Association) -> Any:
         return greenlet_spawn(self.load_association, association)
+
+    def association_loaded(self, association: Association) -> bool:
+        owner = association.__instance_provider__
+        if owner is None:
+            return True
+        state = inspect(cast(Inspectable[InstanceState[Any]], owner))
+        return association.used_name not in state.unloaded

--- a/arcanus/materia/sqlalchemy/base.py
+++ b/arcanus/materia/sqlalchemy/base.py
@@ -71,6 +71,11 @@ class SqlalchemyExpressionCompiler(
             return cast(SQLCoreOperations[bool], native.is_(unwrap(value)))
         if operator == "is_not":
             return cast(SQLCoreOperations[bool], native.is_not(unwrap(value)))
+        if operator == "is_null":
+            return cast(
+                SQLCoreOperations[bool],
+                native.is_(None) if unwrap(value) else native.is_not(None),
+            )
         if operator == "between":
             left, right = cast(tuple[object, object], unwrap(value))
             return cast(SQLCoreOperations[bool], native.between(left, right))
@@ -138,8 +143,13 @@ class SqlalchemyExpressionCompiler(
         )
 
     def order(self, order: Order[Any]) -> SQLCoreOperations[CriteriaValue]:
+        # Null placement is emitted explicitly so every database agrees with
+        # the PostgreSQL defaults (ASC NULLS LAST / DESC NULLS FIRST) — cursor
+        # bookmark comparisons for nullable order keys assume exactly this.
         native = cast(SQLCoreOperations[CriteriaValue], order.column.native)
-        return native.desc() if order.descending else native.asc()
+        if order.descending:
+            return cast(SQLCoreOperations[CriteriaValue], native.desc().nulls_first())
+        return cast(SQLCoreOperations[CriteriaValue], native.asc().nulls_last())
 
 
 class SqlalchemyMateria(BaseMateria):

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -317,18 +317,20 @@ def _render_report(rows: list[GapRow], axis: str) -> None:
         if not ax_rows:
             continue
         table = Table(title=AXIS_TITLES[ax], box=SIMPLE_HEAVY, header_style="bold")
-        table.add_column("group", style="cyan", no_wrap=True)
-        table.add_column("ref µs", justify="right")
-        table.add_column("cand µs", justify="right")
+        # Numeric columns are no_wrap so a narrow terminal never ellipsis-truncates
+        # a figure; the group column folds instead, absorbing the width pressure.
+        table.add_column("group", style="cyan", overflow="fold")
+        table.add_column("ref µs", justify="right", no_wrap=True)
+        table.add_column("cand µs", justify="right", no_wrap=True)
         if ax == "B":
-            table.add_column("ctx µs", justify="right", style="dim")
+            table.add_column("orm µs", justify="right", style="dim", no_wrap=True)
         # Δ µs is left uncolored on purpose: an absolute-µs threshold is
         # scale-dependent (+5µs is huge on a 0.1µs group, invisible on a 600µs
         # one), so it would re-import the very distortion the gap ratio has. The
         # gap column owns the green/yellow/red verdict; Δ µs is the neutral
         # ground truth the reader cross-references against it.
-        table.add_column("Δ µs", justify="right")
-        table.add_column("gap", justify="right")
+        table.add_column("Δ µs", justify="right", no_wrap=True)
+        table.add_column("gap", justify="right", no_wrap=True)
         for row in ax_rows:
             cells = [escape(row.key), _us(row.reference), _us(row.candidate)]
             if ax == "B":

--- a/tests/sqlalchemy/async/test_computed_field_expressions.py
+++ b/tests/sqlalchemy/async/test_computed_field_expressions.py
@@ -18,13 +18,13 @@ from typing import Annotated, Optional
 from uuid import uuid4
 
 import pytest
-from pydantic import ConfigDict, Field, computed_field
+from pydantic import ConfigDict, Field, ValidationError, computed_field
 from sqlalchemy import ForeignKey, String, Text, func, select
 from sqlalchemy.ext.asyncio import AsyncEngine
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from arcanus import Criteria, Cursor, Relation, Relationship
+from arcanus import Criteria, Cursor, Relation, Relationship, provided
 from arcanus.base import BaseTransmuter, Identity
 from arcanus.materia.sqlalchemy import AsyncSession, selectinload
 from tests.models import Base
@@ -91,6 +91,7 @@ class MemoSchema(BaseTransmuter):
     source: Relation[Optional[SourceSchema]] = Relationship()
 
     @computed_field
+    @provided
     @property
     def title(self) -> Optional[str]:
         if self.title_override is not None:
@@ -102,9 +103,16 @@ class MemoSchema(BaseTransmuter):
     def title(self, value: Optional[str]) -> None:
         self.title_override = value
 
+    # Display-only computed field: serialized, but NOT @provided — it must
+    # stay invisible to criteria, Schema[name], and ordering.
+    @computed_field
+    @property
+    def label(self) -> str:
+        return f"memo:{self.title_override or 'untitled'}"
+
 
 async def _seed_memo(
-    session: AsyncSession, source_title: str, override: Optional[str] = None
+    session: AsyncSession, source_title: Optional[str], override: Optional[str] = None
 ) -> MemoSchema:
     source = SourceSchema(title=source_title, summary=f"About {source_title}")
     session.add(source)
@@ -227,10 +235,16 @@ class TestComputedFieldQuerying:
             # The bookmark must carry the REAL computed value through the
             # encode/decode round trip — an unpopulated value would be
             # silently dropped by exclude_none and the cursor would never
-            # advance.
+            # advance. Ascending keys also cover the trailing NULLS LAST
+            # region.
             assert decoded.bookmark.model_dump(
                 mode="json", by_alias=True, exclude_none=True
-            ) == {"title": {"gt": f"{marker} Beta"}}
+            ) == {
+                "or": [
+                    {"title": {"gt": f"{marker} Beta"}},
+                    {"title": {"is_null": True}},
+                ]
+            }
             bookmark_expression = decoded.bookmark.expression
             assert bookmark_expression is not None
             second_items = await session.list(
@@ -308,3 +322,161 @@ class TestComputedFieldReads:
             reloaded = await session.get_one(MemoSchema, memo.id)
             assert reloaded.title_override == f"Edited {marker}"
             assert reloaded.title == f"Edited {marker}"
+
+
+class TestProvidedGate:
+    """Only @provided computed fields join the expression layer."""
+
+    def test_unmarked_computed_field_rejected_as_criteria(self):
+        with pytest.raises(ValidationError):
+            Criteria[MemoSchema].model_validate({"label": {"eq": "memo:x"}})
+
+    def test_unmarked_computed_field_has_no_column(self):
+        with pytest.raises(KeyError):
+            MemoSchema["label"]
+
+    @pytest.mark.asyncio
+    async def test_unmarked_computed_field_still_serializes(
+        self, async_engine: AsyncEngine
+    ):
+        marker = uuid4().hex[:8]
+        async with AsyncSession(async_engine) as session:
+            memo = await _seed_memo(session, f"Quantum {marker}", override=marker)
+            assert memo.model_dump()["label"] == f"memo:{marker}"
+
+
+class TestIsNullOperator:
+    def test_is_null_true_compiles_to_is_null(self):
+        criteria = Criteria[MemoSchema].model_validate(
+            {"title_override": {"is_null": True}}
+        )
+        (expression,) = criteria.expressions
+        sql = str(select(ComputedMemo).where(expression))
+        assert "is null" in sql.lower()
+
+    def test_is_null_false_compiles_to_is_not_null(self):
+        criteria = Criteria[MemoSchema].model_validate(
+            {"title_override": {"is_null": False}}
+        )
+        (expression,) = criteria.expressions
+        sql = str(select(ComputedMemo).where(expression))
+        assert "is not null" in sql.lower()
+
+    @pytest.mark.asyncio
+    async def test_is_null_on_computed_field_filters_rows(
+        self, async_engine: AsyncEngine
+    ):
+        marker = uuid4().hex[:8]
+        async with AsyncSession(async_engine) as session:
+            titled = await _seed_memo(session, f"Quantum {marker}")
+            untitled = await _seed_memo(session, None)
+
+            scope = MemoSchema["id"].in_([titled.id, untitled.id])
+            null_titled = await session.list(
+                MemoSchema,
+                expressions=(scope, MemoSchema["title"].operate("is_null", True)),
+            )
+            assert [memo.id for memo in null_titled] == [untitled.id]
+
+
+class TestNullableCursorPagination:
+    """Cursor pagination over a nullable order key (ASC NULLS LAST / DESC
+    NULLS FIRST), with the null region reached and crossed via bookmarks."""
+
+    async def _seed(self, session: AsyncSession, marker: str) -> list[MemoSchema]:
+        memos = [
+            await _seed_memo(session, f"{marker} Alpha"),
+            await _seed_memo(session, f"{marker} Beta"),
+            await _seed_memo(session, None, override=None),
+            await _seed_memo(session, None, override=None),
+        ]
+        return memos
+
+    async def _walk(
+        self,
+        session: AsyncSession,
+        expressions: tuple,
+        orders: tuple,
+    ) -> list[int | None]:
+        options = (selectinload(MemoSchema["source"]),)
+        collected: list[int | None] = []
+        bookmark_expression = None
+        for _ in range(8):
+            page_expressions = expressions + (
+                (bookmark_expression,) if bookmark_expression is not None else ()
+            )
+            items = await session.list(
+                MemoSchema,
+                limit=1,
+                order_bys=orders,
+                options=options,
+                expressions=page_expressions,
+            )
+            if not items:
+                break
+            collected.append(items[-1].id)
+            bookmark = Cursor[MemoSchema].bookmark_from_item(items[-1], orders)
+            cursor = Cursor[MemoSchema].from_expressions(
+                expressions=expressions,
+                bookmark=bookmark,
+                order_bys=orders,
+                limit=1,
+            )
+            decoded = Cursor[MemoSchema](str(cursor))
+            bookmark_expression = decoded.bookmark.expression
+            assert bookmark_expression is not None
+        return collected
+
+    @pytest.mark.asyncio
+    async def test_ascending_nulls_last_walk(self, async_engine: AsyncEngine):
+        marker = uuid4().hex[:8]
+        async with AsyncSession(async_engine) as session:
+            memos = await self._seed(session, marker)
+            scope = (MemoSchema["id"].in_([memo.id for memo in memos]),)
+            orders = (MemoSchema["title"].asc(), MemoSchema["id"].asc())
+
+            collected = await self._walk(session, scope, orders)
+            assert collected == [memos[0].id, memos[1].id, memos[2].id, memos[3].id]
+
+    @pytest.mark.asyncio
+    async def test_descending_nulls_first_walk(self, async_engine: AsyncEngine):
+        marker = uuid4().hex[:8]
+        async with AsyncSession(async_engine) as session:
+            memos = await self._seed(session, marker)
+            scope = (MemoSchema["id"].in_([memo.id for memo in memos]),)
+            orders = (MemoSchema["title"].desc(), MemoSchema["id"].desc())
+
+            collected = await self._walk(session, scope, orders)
+            assert collected == [memos[3].id, memos[2].id, memos[1].id, memos[0].id]
+
+    @pytest.mark.asyncio
+    async def test_null_bookmark_round_trips_via_is_null(
+        self, async_engine: AsyncEngine
+    ):
+        marker = uuid4().hex[:8]
+        async with AsyncSession(async_engine) as session:
+            memos = await self._seed(session, marker)
+            orders = (MemoSchema["title"].asc(), MemoSchema["id"].asc())
+
+            bookmark = Cursor[MemoSchema].bookmark_from_item(memos[2], orders)
+            cursor = Cursor[MemoSchema].from_expressions(
+                expressions=(MemoSchema["id"].in_([memo.id for memo in memos]),),
+                bookmark=bookmark,
+                order_bys=orders,
+                limit=1,
+            )
+            decoded = Cursor[MemoSchema](str(cursor))
+            dumped = decoded.bookmark.model_dump(
+                mode="json", by_alias=True, exclude_none=True
+            )
+            assert dumped == {
+                "and": [
+                    {"title": {"is_null": True}},
+                    {
+                        "or": [
+                            {"id": {"gt": memos[2].id}},
+                            {"id": {"is_null": True}},
+                        ]
+                    },
+                ]
+            }

--- a/tests/sqlalchemy/async/test_computed_field_expressions.py
+++ b/tests/sqlalchemy/async/test_computed_field_expressions.py
@@ -19,6 +19,7 @@ from uuid import uuid4
 
 import pytest
 from pydantic import ConfigDict, Field, ValidationError, computed_field
+from pydantic_core import PydanticCustomError
 from sqlalchemy import ForeignKey, String, Text, func, select
 from sqlalchemy.ext.asyncio import AsyncEngine
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -26,6 +27,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from arcanus import Criteria, Cursor, Relation, Relationship, provided
 from arcanus.base import BaseTransmuter, Identity
+from arcanus.materia.base import BaseMateria
 from arcanus.materia.sqlalchemy import AsyncSession, selectinload
 from tests.models import Base
 from tests.transmuters import sqlalchemy_materia
@@ -480,3 +482,22 @@ class TestNullableCursorPagination:
                     },
                 ]
             }
+
+
+class TestAssociationLoadedHook:
+    def test_base_materia_treats_associations_as_loaded(self):
+        relation: Relation[SourceSchema] = Relation()
+        assert BaseMateria().association_loaded(relation) is True
+
+    def test_sqlalchemy_materia_without_provider_is_loaded(self):
+        # Unprepared relation: no owner instance, so no provider to inspect.
+        relation: Relation[SourceSchema] = Relation()
+        assert sqlalchemy_materia.association_loaded(relation) is True
+
+
+@pytest.mark.asyncio
+async def test_all_null_bookmark_without_tiebreak_raises(async_engine: AsyncEngine):
+    async with AsyncSession(async_engine) as session:
+        memo = await _seed_memo(session, None)
+        with pytest.raises(PydanticCustomError, match="non-null unique tiebreak"):
+            Cursor[MemoSchema].bookmark_from_item(memo, (MemoSchema["title"].asc(),))

--- a/tests/sqlalchemy/async/test_computed_field_expressions.py
+++ b/tests/sqlalchemy/async/test_computed_field_expressions.py
@@ -1,0 +1,310 @@
+"""Computed fields paired with SQLAlchemy hybrid attributes.
+
+A pydantic ``@computed_field`` on a transmuter, backed by a same-named
+``hybrid_property`` on the ORM provider, behaves like a regular column end
+to end: filterable and orderable through criteria/expressions, readable in
+serialization, usable in cursor bookmarks, and writable when the property
+has a setter. Reads never fire relationship loading — ``Relation.peek()``
+resolves only what is already in memory.
+
+The Memo/SourceDoc pair models the common "user override falls back to the
+related row's value" shape (e.g. a note's title falling back to its
+article's title).
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Optional
+from uuid import uuid4
+
+import pytest
+from pydantic import ConfigDict, Field, computed_field
+from sqlalchemy import ForeignKey, String, Text, func, select
+from sqlalchemy.ext.asyncio import AsyncEngine
+from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from arcanus import Criteria, Cursor, Relation, Relationship
+from arcanus.base import BaseTransmuter, Identity
+from arcanus.materia.sqlalchemy import AsyncSession, selectinload
+from tests.models import Base
+from tests.transmuters import sqlalchemy_materia
+
+
+class ComputedSource(Base):
+    __tablename__ = "computed_source"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    title: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
+class ComputedMemo(Base):
+    __tablename__ = "computed_memo"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    title_override: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    source_id: Mapped[int] = mapped_column(
+        ForeignKey("computed_source.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    source: Mapped[ComputedSource] = relationship(uselist=False)
+
+    @hybrid_property
+    def title(self) -> Optional[str]:
+        if self.title_override is not None:
+            return self.title_override
+        source = self.source
+        return source.title if source is not None else None
+
+    @title.inplace.setter
+    def _title_setter(self, value: Optional[str]) -> None:
+        self.title_override = value
+
+    @title.inplace.expression
+    @classmethod
+    def _title_expression(cls):
+        return func.coalesce(
+            cls.title_override,
+            select(ComputedSource.title)
+            .where(ComputedSource.id == cls.source_id)
+            .scalar_subquery(),
+        )
+
+
+@sqlalchemy_materia.bless(ComputedSource)
+class SourceSchema(BaseTransmuter):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: Annotated[Optional[int], Identity] = Field(default=None, frozen=True)
+    title: Optional[str] = None
+    summary: Optional[str] = None
+
+
+@sqlalchemy_materia.bless(ComputedMemo)
+class MemoSchema(BaseTransmuter):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: Annotated[Optional[int], Identity] = Field(default=None, frozen=True)
+    title_override: Optional[str] = None
+    source_id: Optional[int] = None
+    source: Relation[Optional[SourceSchema]] = Relationship()
+
+    @computed_field
+    @property
+    def title(self) -> Optional[str]:
+        if self.title_override is not None:
+            return self.title_override
+        source = self.source.peek()
+        return source.title if source is not None else None
+
+    @title.setter
+    def title(self, value: Optional[str]) -> None:
+        self.title_override = value
+
+
+async def _seed_memo(
+    session: AsyncSession, source_title: str, override: Optional[str] = None
+) -> MemoSchema:
+    source = SourceSchema(title=source_title, summary=f"About {source_title}")
+    session.add(source)
+    await session.flush()
+    source.revalidate()
+
+    memo = MemoSchema(source_id=source.id, title_override=override)
+    session.add(memo)
+    await session.flush()
+    memo.revalidate()
+    return memo
+
+
+class TestComputedFieldCriteria:
+    def test_subscript_resolves_hybrid_expression(self):
+        expression = MemoSchema["title"].ilike("%quantum%")
+        sql = str(select(ComputedMemo).where(expression))
+        assert "coalesce" in sql.lower()
+        assert "computed_source" in sql
+
+    def test_criteria_model_includes_computed_field(self):
+        criteria = Criteria[MemoSchema].model_validate({"title": {"ilike": "%q%"}})
+        (expression,) = criteria.expressions
+        sql = str(select(ComputedMemo).where(expression))
+        assert "coalesce" in sql.lower()
+
+    def test_computed_field_inside_or_combinator(self):
+        criteria = Criteria[MemoSchema].model_validate(
+            {
+                "or": [
+                    {"title": {"ilike": "%q%"}},
+                    {"title_override": {"eq": "exact"}},
+                ]
+            }
+        )
+        (expression,) = criteria.expressions
+        sql = str(select(ComputedMemo).where(expression))
+        assert " or " in sql.lower()
+        assert "coalesce" in sql.lower()
+
+
+class TestComputedFieldQuerying:
+    @pytest.mark.asyncio
+    async def test_filtering_matches_fallback_and_override(
+        self, async_engine: AsyncEngine
+    ):
+        marker = uuid4().hex[:8]
+        async with AsyncSession(async_engine) as session:
+            fallback_memo = await _seed_memo(session, f"Quantum {marker} Primer")
+            override_memo = await _seed_memo(
+                session,
+                f"Banana {marker} Recipe",
+                override=f"Quantum {marker} Override",
+            )
+
+            matched = await session.list(
+                MemoSchema,
+                expressions=(MemoSchema["title"].ilike(f"%Quantum {marker}%"),),
+            )
+            assert {memo.id for memo in matched} == {
+                fallback_memo.id,
+                override_memo.id,
+            }
+
+            # The override masks the source title: coalesce, not OR.
+            masked = await session.list(
+                MemoSchema,
+                expressions=(MemoSchema["title"].ilike(f"%Banana {marker}%"),),
+            )
+            assert masked == []
+
+    @pytest.mark.asyncio
+    async def test_order_by_effective_title(self, async_engine: AsyncEngine):
+        marker = uuid4().hex[:8]
+        async with AsyncSession(async_engine) as session:
+            zebra = await _seed_memo(session, f"{marker} Zebra")
+            apple = await _seed_memo(session, f"{marker} Apple")
+            mango = await _seed_memo(session, f"Ignored {marker}", f"{marker} Mango")
+
+            memos = await session.list(
+                MemoSchema,
+                expressions=(MemoSchema["title"].ilike(f"%{marker}%"),),
+                order_bys=(MemoSchema["title"].desc(),),
+            )
+            assert [memo.id for memo in memos] == [zebra.id, mango.id, apple.id]
+
+    @pytest.mark.asyncio
+    async def test_cursor_bookmark_reads_computed_value(
+        self, async_engine: AsyncEngine
+    ):
+        marker = uuid4().hex[:8]
+        async with AsyncSession(async_engine) as session:
+            for letter in ("Alpha", "Beta", "Gamma"):
+                await _seed_memo(session, f"{marker} {letter}")
+
+            expressions = (MemoSchema["title"].ilike(f"%{marker}%"),)
+            orders = (MemoSchema["title"].asc(),)
+            options = (selectinload(MemoSchema["source"]),)
+
+            first_items = await session.list(
+                MemoSchema,
+                limit=2,
+                order_bys=orders,
+                options=options,
+                expressions=expressions,
+            )
+            assert [memo.title for memo in first_items] == [
+                f"{marker} Alpha",
+                f"{marker} Beta",
+            ]
+
+            bookmark = Cursor[MemoSchema].bookmark_from_item(first_items[-1], orders)
+            cursor = Cursor[MemoSchema].from_expressions(
+                expressions=expressions,
+                bookmark=bookmark,
+                order_bys=orders,
+                limit=2,
+            )
+            decoded = Cursor[MemoSchema](str(cursor))
+            # The bookmark must carry the REAL computed value through the
+            # encode/decode round trip — an unpopulated value would be
+            # silently dropped by exclude_none and the cursor would never
+            # advance.
+            assert decoded.bookmark.model_dump(
+                mode="json", by_alias=True, exclude_none=True
+            ) == {"title": {"gt": f"{marker} Beta"}}
+            bookmark_expression = decoded.bookmark.expression
+            assert bookmark_expression is not None
+            second_items = await session.list(
+                MemoSchema,
+                limit=2,
+                order_bys=decoded.order_by.orders,
+                options=options,
+                expressions=(*expressions, bookmark_expression),
+            )
+            assert [memo.title for memo in second_items] == [f"{marker} Gamma"]
+
+
+class TestComputedFieldReads:
+    @pytest.mark.asyncio
+    async def test_serialization_resolves_effective_value(
+        self, async_engine: AsyncEngine
+    ):
+        marker = uuid4().hex[:8]
+        async with AsyncSession(async_engine) as session:
+            fallback_memo = await _seed_memo(session, f"Quantum {marker}")
+            override_memo = await _seed_memo(
+                session, f"Banana {marker}", override=f"Override {marker}"
+            )
+
+            memos = await session.list(
+                MemoSchema,
+                expressions=(
+                    MemoSchema["id"].in_([fallback_memo.id, override_memo.id]),
+                ),
+                order_bys=(MemoSchema["id"].asc(),),
+                options=(selectinload(MemoSchema["source"]),),
+            )
+            dumped = [memo.model_dump()["title"] for memo in memos]
+            assert dumped == [f"Quantum {marker}", f"Override {marker}"]
+
+    @pytest.mark.asyncio
+    async def test_peek_never_fires_relationship_loading(
+        self, async_engine: AsyncEngine
+    ):
+        marker = uuid4().hex[:8]
+        async with AsyncSession(async_engine) as session:
+            seeded = await _seed_memo(session, f"Quantum {marker}")
+            await session.commit()
+
+        async with AsyncSession(async_engine) as session:
+            memo = await session.get_one(MemoSchema, seeded.id)
+
+            # The source relationship is NOT loaded: peek must not fire the
+            # lazy load (which would raise MissingGreenlet in async), and the
+            # computed field degrades to None instead of crashing.
+            assert memo.source.loaded is False
+            assert memo.source.peek() is None
+            assert memo.title is None
+            assert memo.model_dump()["title"] is None
+
+            await memo.source
+            assert memo.source.loaded is True
+            assert memo.source.peek() is not None
+            assert memo.title == f"Quantum {marker}"
+
+    @pytest.mark.asyncio
+    async def test_setter_writes_through_to_provider(self, async_engine: AsyncEngine):
+        marker = uuid4().hex[:8]
+        async with AsyncSession(async_engine) as session:
+            memo = await _seed_memo(session, f"Quantum {marker}")
+
+            memo.title = f"Edited {marker}"
+            assert memo.title_override == f"Edited {marker}"
+            provided = memo.__transmuter_provided__
+            assert isinstance(provided, ComputedMemo)
+            assert provided.title_override == f"Edited {marker}"
+            await session.commit()
+
+        async with AsyncSession(async_engine) as session:
+            reloaded = await session.get_one(MemoSchema, memo.id)
+            assert reloaded.title_override == f"Edited {marker}"
+            assert reloaded.title == f"Edited {marker}"

--- a/tests/sqlalchemy/async/test_pagination.py
+++ b/tests/sqlalchemy/async/test_pagination.py
@@ -103,9 +103,15 @@ class TestAsyncCursorPagination:
                 "Async Cursor Manual Page B",
             ]
             assert decoded.order_by == ("+id",)
+            # Ascending keys cover the trailing NULLS LAST region too.
             assert decoded.bookmark.model_dump(
                 mode="json", by_alias=True, exclude_none=True
-            ) == {"id": {"gt": authors[1].id}}
+            ) == {
+                "or": [
+                    {"id": {"gt": authors[1].id}},
+                    {"id": {"is_null": True}},
+                ]
+            }
             assert second_page.has_more is False
             assert second_page.next_cursor is not None
             assert [author.name for author in second_page] == [

--- a/tests/sqlalchemy/sync/test_pagination.py
+++ b/tests/sqlalchemy/sync/test_pagination.py
@@ -99,9 +99,15 @@ class TestCursorPagination:
                 "Cursor Manual Page B",
             ]
             assert decoded.order_by == ("+id",)
+            # Ascending keys cover the trailing NULLS LAST region too.
             assert decoded.bookmark.model_dump(
                 mode="json", by_alias=True, exclude_none=True
-            ) == {"id": {"gt": authors[1].id}}
+            ) == {
+                "or": [
+                    {"id": {"gt": authors[1].id}},
+                    {"id": {"is_null": True}},
+                ]
+            }
             assert second_page.has_more is False
             assert second_page.next_cursor is not None
             assert [author.name for author in second_page] == [

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -311,6 +311,8 @@ def test_native_expression_compiler_operator_branches():
 
     assert compiler.apply(column, "is_", None) == ("is", None)
     assert compiler.apply(column, "is_not", None) == ("is_not", None)
+    assert compiler.apply(column, "is_null", True) == ("is", None)
+    assert compiler.apply(column, "is_null", False) == ("is_not", None)
     assert compiler.apply(column, "between", (1, 2)) == ("between", 1, 2)
     assert compiler.apply(column, "eq", "Ada") == ("eq", "Ada")
     assert compiler.apply(column, "not_contains", "bot") == ("not",)


### PR DESCRIPTION
## Summary

A pydantic `@computed_field` on a transmuter, marked with the new `@provided` decorator and paired with a same-named expression-capable attribute on the provider (e.g. a SQLAlchemy `hybrid_property`), now behaves like a regular column across the whole stack.

## What changed

- **`@provided` marker** (`base.py`): computed fields join the expression layer only when explicitly marked. The decorator stacks anywhere around `computed_field`/`property` (the mark lives on the getter, so `@x.setter` rebinds keep it). Unmarked computed fields stay serialization-only, and subscripting one raises a descriptive `KeyError` instead of pydantic's generic-parametrization `TypeError`.
- **`Schema[name]` resolution** (`base.py`): `__class_getitem__`, the metaclass `__getitem__`, and `_column` resolve `@provided` computed names, synthesizing the `FieldInfo` from `ComputedFieldInfo.return_type`/`alias` and handing the provider's same-named attribute to the materia. Filters and `order_by` compile through the hybrid's SQL expression.
- **Criteria generation** (`criteria.py`): `__get_generic_model_value_annotations__` feeds the field-definitions and examples loops with regular fields plus `@provided` computed fields keyed by return type, so they are filterable/orderable via query params and usable inside `and`/`or`/`not` combinators.
- **`Association.loaded` / `Association.peek()`** (`association.py`), backed by the new `BaseMateria.association_loaded` hook (SQLAlchemy: `used_name not in InstanceState.unloaded`): read an association without ever firing a provider load. Computed getters built on `peek()` respect relationship loading by construction — unloaded relations degrade to `None` instead of raising `MissingGreenlet`.
- **Null-safe cursor pagination** (`criteria.py`, both compilers):
  - new public `is_null` operator on `BaseCriteria` (compiled to `IS NULL`/`IS NOT NULL`) — the encoding vehicle for null bookmark values, since any `{op: null}` form is dropped by `exclude_none`; also a generally useful filter.
  - the SQLAlchemy compiler emits `ASC NULLS LAST` / `DESC NULLS FIRST` explicitly — PostgreSQL's defaults (production SQL and index behavior unchanged), normalizing SQLite to agree.
  - `bookmark_from_item` builds null-aware strictly-after comparisons per order key. Ascending bookmarks also cover the trailing null region, so the encoded shape gains an `or`/`is_null` branch (semantically identical for non-null columns; old cursors still decode). Degenerate all-null bookmarks raise `invalid_cursor`.
- Construction/`model_formulate` already excluded computed fields from provider kwargs; unchanged.

Also rides along: the PR-title conventional-commit check is now blocking (workflow + CONTRIBUTING), and benchmark table numeric columns no longer wrap.

## Test plan

- `tests/sqlalchemy/async/test_computed_field_expressions.py` (18 tests) with a Memo/Source pair modeling the override-falls-back shape: subscript→coalesce SQL, criteria inclusion, or-combinator, end-to-end filtering (override masks source), order-by-effective-value, cursor bookmark encode/decode round trip, serialization, peek-never-fires-load, setter write-through, the `@provided` gate (unmarked field serializes but is rejected as criteria and unsubscriptable), `is_null` compile + end-to-end, and nullable-key cursor walks in both directions crossing the null region.
- Full suite: 981 passed, 1 skipped. ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)