### PR TITLE
ci: pass a workflow-triggering token to release-please

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,9 +19,16 @@ jobs:
             release_created: ${{ steps.release.outputs.release_created }}
             tag_name: ${{ steps.release.outputs.tag_name }}
         steps:
+            # Events created with the default GITHUB_TOKEN never trigger other
+            # workflows, so release PRs opened with it get no CI runs and stay
+            # blocked on required checks. RELEASE_PLEASE_TOKEN must be a
+            # fine-grained PAT (contents + pull-requests: write); until the
+            # secret exists this falls back to the old behavior, where the
+            # release PR needs a manual close/reopen to start its checks.
             - uses: googleapis/release-please-action@v4
               id: release
               with:
+                  token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
                   config-file: release-please-config.json
                   manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Summary

Release-please runs in publish.yml with the default `GITHUB_TOKEN`. GitHub suppresses events created by that token (anti-recursion), so the release PRs it opens — like #44 — trigger **zero** workflow runs: required checks sit in Expected state forever and the PR is blocked. #44 needed a manual close/reopen to start its checks.

This passes `RELEASE_PLEASE_TOKEN` to the action when the secret exists, falling back to `github.token` until then, so the workflow keeps working before the secret is created.

## Follow-up required (repo admin)

Create a fine-grained PAT with **contents: write** and **pull-requests: write** scoped to this repo, and add it as the `RELEASE_PLEASE_TOKEN` repository secret. Until then, release PRs still need the close/reopen ritual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)