### PR TITLE
ci: deploy docs via GitHub Pages Actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,21 +5,23 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Deploy to GitHub Pages via the Pages API (no gh-pages branch push).
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
 
+# One deployment at a time; don't cancel an in-progress publish.
 concurrency:
-  group: docs-${{ github.ref }}
-  cancel-in-progress: true
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  deploy:
-    name: Build & Deploy
+  build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -35,10 +37,25 @@ jobs:
       - name: Install docs dependencies
         run: uv sync --group docs
 
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Build site
+        run: uv run mkdocs build
 
-      - name: Build & deploy to gh-pages
-        run: uv run mkdocs gh-deploy --force
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Switch the Docs workflow to the **GitHub Pages Actions** deployment — build the site, upload it as a Pages artifact, and publish with `actions/deploy-pages`. No `gh-pages` branch push, so the ruleset no longer blocks it. Adds `pages: write` / `id-token: write` permissions and the `github-pages` environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)